### PR TITLE
Add SENTRY_PIPELINE to GitHub Action

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "license": "MIT",
   "dependencies": {
     "@actions/core": "^1.2.4",
-    "@sentry/cli": "^1.54.0",
+    "@sentry/cli": "^1.55.0",
     "@sentry/types": "^5.17.0"
   },
   "devDependencies": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,7 +10,7 @@ import {version} from '../package.json';
 let cli: Releases;
 export const getCLI = (): Releases => {
   // Set the User-Agent string.
-  process.env['SENTRY_PIPELINE'] = `action-release/${version}`;
+  process.env['SENTRY_PIPELINE'] = `github-action-release/${version}`;
 
   if (!cli) {
     cli = new SentryCli().releases;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,6 @@
 import SentryCli, {Releases} from '@sentry/cli';
+// @ts-ignore
+import {version} from '../package.json';
 
 /**
  * CLI Singleton
@@ -7,6 +9,9 @@ import SentryCli, {Releases} from '@sentry/cli';
  */
 let cli: Releases;
 export const getCLI = (): Releases => {
+  // Set the User-Agent string.
+  process.env['SENTRY_PIPELINE'] = `action-release/${version}`;
+
   if (!cli) {
     cli = new SentryCli().releases;
     if (process.env['MOCK']) {


### PR DESCRIPTION
When a release is created with the Github Action, Sentry gets told about it via the User Agent string.