### PR TITLE
Release Prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ The following are all _required_.
 |`sourcemaps`|Space-separated list of paths to JavaScript sourcemaps. Omit to skip uploading sourcemaps.|-|
 |`started_at`|Unix timestamp of the release start date. Omit for current time.|-|
 |`version`|Identifier that uniquely identifies the releases. _Note: the `refs/tags/` prefix is automatically stripped when `version` is `github.ref`._|<code>${{&nbsp;github.sha&nbsp;}}</code>|
+|`version_prefix`|Value prepended to auto-generated version. For example "v".|-|
 
 ### Examples
 - Create a new Sentry release for the `production` environment and upload JavaScript source maps from the `./lib` directory.

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -9,6 +9,10 @@ import {
 } from '../src/validate'
 
 describe('validate', () => {
+  beforeAll(() => {
+    process.env['MOCK'] = "true";
+  });
+
   describe('getShouldFinalize', () => {
     const errorMessage = 'finalize is not a boolean';
     afterEach(() => {
@@ -82,22 +86,25 @@ describe('validate', () => {
   });
 
   describe('getVersion', () => {
+    const MOCK_VERSION = "releases propose-version";
     afterEach(() => {
       delete process.env['INPUT_VERSION'];
+      delete process.env['INPUT_VERSION_PREFIX'];
     });
 
     test('should strip refs from version', async () => {
       process.env['INPUT_VERSION'] = 'refs/tags/v1.0.0';
-      expect(getVersion()).toBe('v1.0.0')
+      expect(await getVersion()).toBe('v1.0.0')
     });
 
     test('should get version from inputs', async () => {
       process.env['INPUT_VERSION'] = 'v1.0.0';
-      expect(getVersion()).toBe('v1.0.0')
+      expect(await getVersion()).toBe('v1.0.0')
     });
 
     test('should propose-version when version is omitted', async () => {
-      expect(getVersion()).toBe('propose-version')
+      expect(await getVersion()).toBe(MOCK_VERSION)
+    });
     });
   });
 });

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -105,6 +105,10 @@ describe('validate', () => {
     test('should propose-version when version is omitted', async () => {
       expect(await getVersion()).toBe(MOCK_VERSION)
     });
+
+    test('should include prefix in version', async () => {
+      process.env['INPUT_VERSION_PREFIX'] = 'prefix-';
+      expect(await getVersion()).toBe(`prefix-${MOCK_VERSION}`)
     });
   });
 });

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,9 @@ inputs:
   version:
     description: 'Identifier that uniquely identifies the releases. Omit to auto-generate one.'
     required: false
+  version_prefix:
+    description: 'Value prepended to auto-generated version.'
+    required: false
 runs:
   using: 'docker'
   image: 'docker://sentryintegrations/sentry-github-action-release:latest'

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -8,13 +8,20 @@ import {getCLI} from './cli';
  */
 export const getVersion = async (): Promise<string> => {
   const versionOption: string = core.getInput('version');
+  const versionPrefixOption: string = core.getInput('version_prefix');
   if (versionOption) {
     // If the users passes in `${{github.ref}}, then it will have an unwanted prefix.
     return versionOption.replace(/^(refs\/tags\/)/, '');
   }
 
   core.debug('Version not provided, proposing one...');
-  return getCLI().proposeVersion();
+  const version = await getCLI().proposeVersion();
+
+  if (versionPrefixOption) {
+    return `${versionPrefixOption}${version}`;
+  }
+
+  return version;
 };
 
 /**

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -40,11 +40,12 @@ export const getStartedAt = (): number | null => {
   }
 
   // In sentry-cli, we parse integer first.
+  const isStartedAtAnInteger = /^-?[\d]+$/.test(startedAtOption);
   const startedAtTimestamp = parseInt(startedAtOption);
   const startedAt8601 = Math.floor(Date.parse(startedAtOption) / 1000);
 
   let outputTimestamp;
-  if (!isNaN(startedAtTimestamp)) {
+  if (isStartedAtAnInteger && !isNaN(startedAtTimestamp)) {
     outputTimestamp = startedAtTimestamp;
   } else if (!isNaN(startedAt8601)) {
     outputTimestamp = startedAt8601;


### PR DESCRIPTION
Allow users to set a prefix to the automatically generated version. For example prepend `version-` to the hash to get `version-444d9525595959e430e19729ca9e125ed786c756`.