### PR TITLE
Strip ref from version

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The following are all _required_.
 |`finalize`|When false, omit marking the release as finalized and released.|`true`|
 |`sourcemaps`|Space-separated list of paths to JavaScript sourcemaps. Omit to skip uploading sourcemaps.|-|
 |`started_at`|Unix timestamp of the release start date. Omit for current time.|-|
-|`version`|Identifier that uniquely identifies the releases.|<code>${{&nbsp;github.sha&nbsp;}}</code>|
+|`version`|Identifier that uniquely identifies the releases. _Note: the `refs/tags/` prefix is automatically stripped when `version` is `github.ref`._|<code>${{&nbsp;github.sha&nbsp;}}</code>|
 
 ### Examples
 - Create a new Sentry release for the `production` environment and upload JavaScript source maps from the `./lib` directory.

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -1,7 +1,12 @@
 import {execSync} from 'child_process';
 import * as path from 'path';
 import * as process from 'process';
-import {getShouldFinalize, getSourcemaps, getStartedAt} from '../src/validate'
+import {
+  getShouldFinalize,
+  getSourcemaps,
+  getStartedAt,
+  getVersion,
+} from '../src/validate'
 
 describe('validate', () => {
   describe('getShouldFinalize', () => {
@@ -73,6 +78,26 @@ describe('validate', () => {
     test('should return an integer when started_at is an integer.', async () => {
       process.env['INPUT_STARTED_AT'] = '1500000000';
       expect(getStartedAt()).toEqual(1500000000);
+    });
+  });
+
+  describe('getVersion', () => {
+    afterEach(() => {
+      delete process.env['INPUT_VERSION'];
+    });
+
+    test('should strip refs from version', async () => {
+      process.env['INPUT_VERSION'] = 'refs/tags/v1.0.0';
+      expect(getVersion()).toBe('v1.0.0')
+    });
+
+    test('should get version from inputs', async () => {
+      process.env['INPUT_VERSION'] = 'v1.0.0';
+      expect(getVersion()).toBe('v1.0.0')
+    });
+
+    test('should propose-version when version is omitted', async () => {
+      expect(getVersion()).toBe('propose-version')
     });
   });
 });

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -9,7 +9,8 @@ import {getCLI} from './cli';
 export const getVersion = async (): Promise<string> => {
   const versionOption: string = core.getInput('version');
   if (versionOption) {
-    return versionOption;
+    // If the users passes in `${{github.ref}}, then it will have an unwanted prefix.
+    return versionOption.replace(/^(refs\/tags\/)/, '');
   }
 
   core.debug('Version not provided, proposing one...');


### PR DESCRIPTION
If the users passes in `${{github.ref}}`, then strip off the unwanted `"refs/tags/"` prefix.
