### PR TITLE
feat: add set commits option

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -6,11 +6,12 @@ import {
   getSourcemaps,
   getStartedAt,
   getVersion,
-} from '../src/validate'
+  getSetCommitsOption,
+} from '../src/validate';
 
 describe('validate', () => {
   beforeAll(() => {
-    process.env['MOCK'] = "true";
+    process.env['MOCK'] = 'true';
   });
 
   describe('getShouldFinalize', () => {
@@ -50,7 +51,8 @@ describe('validate', () => {
   });
 
   describe('getStartedAt', () => {
-    const errorMessage = 'started_at not in valid format. Unix timestamp or ISO 8601 date expected';
+    const errorMessage =
+      'started_at not in valid format. Unix timestamp or ISO 8601 date expected';
     afterEach(() => {
       delete process.env['INPUT_STARTED_AT'];
     });
@@ -86,7 +88,7 @@ describe('validate', () => {
   });
 
   describe('getVersion', () => {
-    const MOCK_VERSION = "releases propose-version";
+    const MOCK_VERSION = 'releases propose-version';
     afterEach(() => {
       delete process.env['INPUT_VERSION'];
       delete process.env['INPUT_VERSION_PREFIX'];
@@ -94,21 +96,43 @@ describe('validate', () => {
 
     test('should strip refs from version', async () => {
       process.env['INPUT_VERSION'] = 'refs/tags/v1.0.0';
-      expect(await getVersion()).toBe('v1.0.0')
+      expect(await getVersion()).toBe('v1.0.0');
     });
 
     test('should get version from inputs', async () => {
       process.env['INPUT_VERSION'] = 'v1.0.0';
-      expect(await getVersion()).toBe('v1.0.0')
+      expect(await getVersion()).toBe('v1.0.0');
     });
 
     test('should propose-version when version is omitted', async () => {
-      expect(await getVersion()).toBe(MOCK_VERSION)
+      expect(await getVersion()).toBe(MOCK_VERSION);
     });
 
     test('should include prefix in version', async () => {
       process.env['INPUT_VERSION_PREFIX'] = 'prefix-';
-      expect(await getVersion()).toBe(`prefix-${MOCK_VERSION}`)
+      expect(await getVersion()).toBe(`prefix-${MOCK_VERSION}`);
+    });
+  });
+  describe('getSetCommitsOption', () => {
+    afterEach(() => {
+      delete process.env['INPUT_SET_COMMITS'];
+    });
+
+    it('no option', () => {
+      expect(getSetCommitsOption()).toBe('auto');
+    });
+    it('auto', () => {
+      process.env['INPUT_SET_COMMITS'] = 'auto';
+      expect(getSetCommitsOption()).toBe('auto');
+    });
+    it('skip', () => {
+      process.env['INPUT_SET_COMMITS'] = 'skip';
+      expect(getSetCommitsOption()).toBe('skip');
+    });
+    it('bad option', () => {
+      const errorMessage = 'set-commits must be "auto" or "skip"';
+      process.env['INPUT_SET_COMMITS'] = 'bad';
+      expect(() => getSetCommitsOption()).toThrow(errorMessage);
     });
   });
 });

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ inputs:
     required: false
 runs:
   using: 'docker'
-  image: 'Dockerfile'
+  image: 'docker://sentryintegrations/sentry-github-action-release:latest'
 branding:
   icon: 'triangle'
   color: 'purple'

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ inputs:
     required: false
 runs:
   using: 'docker'
-  image: 'docker://sentryintegrations/sentry-github-action-release:latest'
+  image: 'Dockerfile'
 branding:
   icon: 'triangle'
   color: 'purple'

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,8 +19,8 @@ import * as validate from './validate';
     core.debug(`Version is ${version}`);
     await cli.new(version);
 
+    core.debug(`Setting commits with option ${setCommitsOption}`);
     if (setCommitsOption !== 'skip') {
-      core.debug(`Setting commits`);
       await cli.setCommits(version, {auto: true});
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,7 +19,7 @@ import * as validate from './validate';
     core.debug(`Version is ${version}`);
     await cli.new(version);
 
-    core.debug(`Setting commits with option ${setCommitsOption}`);
+    core.debug(`Setting commits with option '${setCommitsOption}'`);
     if (setCommitsOption !== 'skip') {
       await cli.setCommits(version, {auto: true});
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,14 +12,17 @@ import * as validate from './validate';
     const sourcemaps = validate.getSourcemaps();
     const shouldFinalize = validate.getShouldFinalize();
     const deployStartedAtOption = validate.getStartedAt();
+    const setCommitsOption = validate.getSetCommitsOption();
 
     const version = await validate.getVersion();
 
     core.debug(`Version is ${version}`);
     await cli.new(version);
 
-    core.debug(`Setting commits`);
-    await cli.setCommits(version, {auto: true});
+    if (setCommitsOption !== 'skip') {
+      core.debug(`Setting commits`);
+      await cli.setCommits(version, {auto: true});
+    }
 
     if (sourcemaps) {
       core.debug(`Adding sourcemaps`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,8 +19,8 @@ import * as validate from './validate';
     core.debug(`Version is ${version}`);
     await cli.new(version);
 
-    core.debug(`Setting commits with option '${setCommitsOption}'`);
     if (setCommitsOption !== 'skip') {
+      core.debug(`Setting commits with option '${setCommitsOption}'`);
       await cli.setCommits(version, {auto: true});
     }
 

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -104,6 +104,24 @@ export const getShouldFinalize = (): boolean => {
   throw Error('finalize is not a boolean');
 };
 
+export const getSetCommitsOption = (): 'auto' | 'skip' => {
+  let setCommitOption = core.getInput('set_commits');
+  // default to auto
+  if (!setCommitOption) {
+    return 'auto';
+  }
+  // convert to lower case
+  setCommitOption = setCommitOption.toLowerCase();
+  switch (setCommitOption) {
+    case 'auto':
+      return 'auto';
+    case 'skip':
+      return 'skip';
+    default:
+      throw Error('set-commits must be "auto" or "skip"');
+  }
+};
+
 /**
  * Check for required environment variables.
  */


### PR DESCRIPTION
This PR adds a new option for setting commits: `set_commits`. Currently, it only takes two values: `auto` and `skip`. If no value is provided, we pick `auto`. When `auto` is provided, we automatically try to associate commits with the users' source code provider that's installed. If `skip` is provided, we just don't set commits.

Resolves https://github.com/getsentry/action-release/issues/21