### PR TITLE
feat: multiple project options

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -7,6 +7,7 @@ import {
   getStartedAt,
   getVersion,
   getSetCommitsOption,
+  getProjects,
 } from '../src/validate';
 
 describe('validate', () => {
@@ -133,6 +134,25 @@ describe('validate', () => {
       const errorMessage = 'set_commits must be "auto" or "skip"';
       process.env['INPUT_SET_COMMITS'] = 'bad';
       expect(() => getSetCommitsOption()).toThrow(errorMessage);
+    });
+  });
+  describe('getProjects', () => {
+    afterEach(() => {
+      delete process.env['SENTRY_PROJECT'];
+      delete process.env['INPUT_PROJECTS'];
+    });
+    it('read from env variable', () => {
+      process.env['SENTRY_PROJECT'] = 'my-proj';
+      expect(getProjects()).toEqual(['my-proj']);
+    });
+    it('read from option', () => {
+      process.env['INPUT_PROJECTS'] = 'my-proj1 my-proj2';
+      expect(getProjects()).toEqual(['my-proj1', 'my-proj2']);
+    });
+    it('throws error if no project', () => {
+      expect(() => getProjects()).toThrowError(
+        'Environment variable SENTRY_PROJECT is missing a project slug and no projects are specified with the "projects" option'
+      );
     });
   });
 });

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -149,6 +149,11 @@ describe('validate', () => {
       process.env['INPUT_PROJECTS'] = 'my-proj1 my-proj2';
       expect(getProjects()).toEqual(['my-proj1', 'my-proj2']);
     });
+    it('option overwites env variable', () => {
+      process.env['SENTRY_PROJECT'] = 'my-proj';
+      process.env['INPUT_PROJECTS'] = 'my-proj1 my-proj2';
+      expect(getProjects()).toEqual(['my-proj1', 'my-proj2']);
+    });
     it('throws error if no project', () => {
       expect(() => getProjects()).toThrowError(
         'Environment variable SENTRY_PROJECT is missing a project slug and no projects are specified with the "projects" option'

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,9 @@ inputs:
   set_commits:
     description: 'Specify whether to set commits for the release. Either "auto" or "skip".'
     required: false
+  projects:
+    description: 'Space-separated list of projects. Defaults to the env variable "SENTRY_PROJECT" if not provided.'
+    required: false
 runs:
   using: 'docker'
   image: 'docker://sentryintegrations/sentry-github-action-release:latest'

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "license": "MIT",
   "dependencies": {
     "@actions/core": "^1.2.4",
-    "@sentry/cli": "^1.55.0",
+    "@sentry/cli": "^1.59.0",
     "@sentry/types": "^5.17.0"
   },
   "devDependencies": {

--- a/src/sentry-cli.d.ts
+++ b/src/sentry-cli.d.ts
@@ -1,7 +1,7 @@
 declare module '@sentry/cli' {
   export class Releases {
     constructor(configFile?: string, options?: {silent?: boolean});
-    new(release: string): Promise<void>;
+    new(release: string, options?: {projects: string[]}): Promise<void>;
     setCommits(
       release: string,
       options: {
@@ -27,6 +27,7 @@ declare module '@sentry/cli' {
         urlPrefix?: string;
         urlSuffix?: string;
         ext?: string[];
+        projects?: [string]; //only one project allowed (for now)
       }
     ): Promise<void>;
     listDeploys(release: string): Promise<string[]>;

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -131,11 +131,6 @@ export const checkEnvironmentVariables = (): void => {
       'Environment variable SENTRY_ORG is missing an organization slug'
     );
   }
-  if (!process.env['SENTRY_PROJECT']) {
-    throw Error(
-      'Environment variable SENTRY_PROJECT is missing a project slug'
-    );
-  }
   if (!process.env['SENTRY_AUTH_TOKEN']) {
     throw Error(
       'Environment variable SENTRY_AUTH_TOKEN is missing an auth token'

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -142,3 +142,18 @@ export const checkEnvironmentVariables = (): void => {
     );
   }
 };
+
+export const getProjects = (): string[] => {
+  const projectsOption = core.getInput('projects') || '';
+  const projects = projectsOption.split(',').map(proj => proj.trim());
+  if (projects.length > 0) {
+    return projects;
+  }
+  const project = process.env['SENTRY_PROJECT'];
+  if (!project) {
+    throw Error(
+      'Environment variable SENTRY_PROJECT is missing a project slug and no projects are specified with the "projects" option'
+    );
+  }
+  return [project];
+};

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -140,7 +140,10 @@ export const checkEnvironmentVariables = (): void => {
 
 export const getProjects = (): string[] => {
   const projectsOption = core.getInput('projects') || '';
-  const projects = projectsOption.split(' ').filter(proj => !!proj);
+  const projects = projectsOption
+    .split(' ')
+    .map(proj => proj.trim())
+    .filter(proj => !!proj);
   if (projects.length > 0) {
     return projects;
   }

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -140,7 +140,10 @@ export const checkEnvironmentVariables = (): void => {
 
 export const getProjects = (): string[] => {
   const projectsOption = core.getInput('projects') || '';
-  const projects = projectsOption.split(',').map(proj => proj.trim());
+  const projects = projectsOption
+    .split(',')
+    .map(proj => proj.trim())
+    .filter(proj => !!proj);
   if (projects.length > 0) {
     return projects;
   }

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -140,10 +140,7 @@ export const checkEnvironmentVariables = (): void => {
 
 export const getProjects = (): string[] => {
   const projectsOption = core.getInput('projects') || '';
-  const projects = projectsOption
-    .split(',')
-    .map(proj => proj.trim())
-    .filter(proj => !!proj);
+  const projects = projectsOption.split(' ').filter(proj => !!proj);
   if (projects.length > 0) {
     return projects;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -469,10 +469,10 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@sentry/cli@^1.55.0":
-  version "1.55.0"
-  resolved "https://registry.yarnpkg.com/@sentry/cli/-/cli-1.55.0.tgz#0da95cd9491e11da52b15796bded72480f69591b"
-  integrity sha512-LOpM69Kvfaossq92wgP8cg3+0XBc9lg76udH4OdmpSZhtavS/qxWedBsnTicaT//7rQUNZBUnTPOpmCYnpGEIA==
+"@sentry/cli@^1.59.0":
+  version "1.59.0"
+  resolved "https://registry.yarnpkg.com/@sentry/cli/-/cli-1.59.0.tgz#8154c6426a105c6c8a2437db085837aff8e29834"
+  integrity sha512-9nK4uVHW7HIbOwFZNvHRWFJcD+bqjW3kMWK2UUMqQWse0Lf3xM+2o+REGGkk0S69+E4elSiukVjUPTI5aijNlA==
   dependencies:
     https-proxy-agent "^5.0.0"
     mkdirp "^0.5.5"


### PR DESCRIPTION
This PR allows creating a release on multiple projects at once with a space-separated list of projects. Here's how you'd configure that in your `deploy.yml` file:
```
    - name: Sentry Release
      uses: getsentry/action-release@v1
      with:
        projects: project1 project2
```

If you specify `projects`, then it does not read the project from the environment variable `SENTRY_PROJECT` which is not required. Conversely, if you omit `projects` then `SENTRY_PROJECT` is still required.

Fixes: https://github.com/getsentry/action-release/issues/29