### PR TITLE
feat: url prefix for source maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ The following are all _required_.
 |`version`|Identifier that uniquely identifies the releases. _Note: the `refs/tags/` prefix is automatically stripped when `version` is `github.ref`._|<code>${{&nbsp;github.sha&nbsp;}}</code>|
 |`version_prefix`|Value prepended to auto-generated version. For example "v".|-|
 |`set_commits`|Specify whether to set commits for the release. Either "auto" or "skip".|"auto"|
+|`projects`|Space-separated list of paths of projects. Omits falls back to the environment variable `SENTRY_PROJECT` to determine the project.|-|
+|`url_prefix`|Adds a prefix source map urls after stripping them.|-|
 
 ### Examples
 - Create a new Sentry release for the `production` environment and upload JavaScript source maps from the `./lib` directory.

--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ The following are all _required_.
 |`version`|Identifier that uniquely identifies the releases. _Note: the `refs/tags/` prefix is automatically stripped when `version` is `github.ref`._|<code>${{&nbsp;github.sha&nbsp;}}</code>|
 |`version_prefix`|Value prepended to auto-generated version. For example "v".|-|
 |`set_commits`|Specify whether to set commits for the release. Either "auto" or "skip".|"auto"|
-|`projects`|Space-separated list of paths of projects. Omits falls back to the environment variable `SENTRY_PROJECT` to determine the project.|-|
-|`url_prefix`|Adds a prefix source map urls after stripping them.|-|
+|`projects`|Space-separated list of paths of projects. When omitted, falls back to the environment variable `SENTRY_PROJECT` to determine the project.|-|
+|`url_prefix`|Adds a prefix to source map urls after stripping them.|-|
 
 ### Examples
 - Create a new Sentry release for the `production` environment and upload JavaScript source maps from the `./lib` directory.

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -8,6 +8,7 @@ import {
   getVersion,
   getSetCommitsOption,
   getProjects,
+  getUrlPrefixOption,
 } from '../src/validate';
 
 describe('validate', () => {
@@ -160,6 +161,15 @@ describe('validate', () => {
       );
     });
   });
+  describe('getUrlPrefixOption', () => {
+    afterEach(() => {
+      delete process.env['URL_PREFIX'];
+    });
+    it('get url prefix', () => {
+      process.env['INPUT_URL_PREFIX'] = 'build';
+      expect(getUrlPrefixOption()).toEqual('build');
+    })
+  })
 });
 
 // shows how the runner will run a javascript action with env / stdout protocol

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "action-release",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "private": true,
   "description": "GitHub Action for creating a release on Sentry",
   "main": "dist/index.js",

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,7 +26,7 @@ import * as validate from './validate';
       await cli.setCommits(version, {auto: true});
     }
 
-    if (sourcemaps) {
+    if (sourcemaps.length) {
       core.debug(`Adding sourcemaps`);
       await Promise.all(
         projects.map(async project => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,6 +14,7 @@ import * as validate from './validate';
     const deployStartedAtOption = validate.getStartedAt();
     const setCommitsOption = validate.getSetCommitsOption();
     const projects = validate.getProjects();
+    const urlPrefix = validate.getUrlPrefixOption();
 
     const version = await validate.getVersion();
 
@@ -34,6 +35,7 @@ import * as validate from './validate';
           const sourceMapOptions = {
             include: sourcemaps,
             projects: localProjects,
+            urlPrefix,
           };
           return cli.uploadSourceMaps(version, sourceMapOptions);
         })

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -155,3 +155,7 @@ export const getProjects = (): string[] => {
   }
   return [project];
 };
+
+export const getUrlPrefixOption = (): string => {
+  return core.getInput('url_prefix');
+}


### PR DESCRIPTION
This PR adds a new option for the URL prefix used for source maps: `url_prefix`. Example:
```
    - name: Sentry Release
      uses: getsentry/action-release@v1
      with:
        environment: production
        sourcemaps: build/static/js
        url_prefix: ~/static/js
```
This option adds a prefix to the source map URLs after stripping them.

I also updated the readme with the new project options which I apparently missed before.