### PR TITLE
make environment input parameter optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Sentry Release GitHub Action
 Automatically create a Sentry release in a workflow. 
 
-A release is a version of your code that is deployed to an environment. When you give Sentry information about your releases, you unlock a number of new features:
+A release is a version of your code that can be deployed to an environment. When you give Sentry information about your releases, you unlock a number of new features:
  - Determine the issues and regressions introduced in a new release
  - Predict which commit caused an issue and who is likely responsible
  - Resolve issues by including the issue number in your commit message
@@ -46,7 +46,7 @@ The following are all _required_.
 #### Parameters
 |name|description|default|
 |---|---|---|
-|`environment`|_Required_. Set the environment for this release. E.g. "production" or "staging".|-|
+|`environment`|Set the environment for this release. E.g. "production" or "staging". Omit to skip adding deploy to release.|-|
 |`finalize`|When false, omit marking the release as finalized and released.|`true`|
 |`sourcemaps`|Space-separated list of paths to JavaScript sourcemaps. Omit to skip uploading sourcemaps.|-|
 |`started_at`|Unix timestamp of the release start date. Omit for current time.|-|

--- a/action.yml
+++ b/action.yml
@@ -3,8 +3,8 @@ description: 'GitHub Action for creating a release on Sentry'
 author: 'Sentry'
 inputs:
   environment:
-    description: 'Set the environment for this release. E.g. "production" or "staging".'
-    required: true
+    description: 'Set the environment for this release. E.g. "production" or "staging". Omit to skip adding deploy to release.'
+    required: false
   sourcemaps:
     description: 'Space-separated list of paths to JavaScript sourcemaps. Omit to skip uploading sourcemaps.'
     required: false

--- a/src/main.ts
+++ b/src/main.ts
@@ -42,11 +42,13 @@ import * as validate from './validate';
       );
     }
 
-    core.debug(`Adding deploy to release`);
-    await cli.newDeploy(version, {
-      env: environment,
-      ...(deployStartedAtOption && {started: deployStartedAtOption}),
-    });
+    if (environment) {
+      core.debug(`Adding deploy to release`);
+      await cli.newDeploy(version, {
+        env: environment,
+        ...(deployStartedAtOption && {started: deployStartedAtOption}),
+      });
+    }
 
     core.debug(`Finalizing the release`);
     if (shouldFinalize) {

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -30,7 +30,7 @@ export const getVersion = async (): Promise<string> => {
  * @returns string
  */
 export const getEnvironment = (): string => {
-  return core.getInput('environment', {required: true});
+  return core.getInput('environment');
 };
 
 /**


### PR DESCRIPTION
Made `environment` input parameter optional.

Issue #19 