### PR TITLE
Adds missing url_prefix input in action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,9 @@ inputs:
   projects:
     description: 'Space-separated list of projects. Defaults to the env variable "SENTRY_PROJECT" if not provided.'
     required: false
+  url_prefix:
+    description: 'Adds a prefix to source map urls after stripping them.'
+    required: false
 runs:
   using: 'docker'
   image: 'docker://sentryintegrations/sentry-github-action-release:latest'


### PR DESCRIPTION
Seems like `action.yml` is missing the `url_prefix` input, which causes Github to throw a warning: 

![image](https://user-images.githubusercontent.com/1001391/100613427-d290ce80-3314-11eb-994f-7200b1a44907.png)
