### PR TITLE
Add default for url_prefix.

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -163,5 +163,10 @@ export const getProjects = (): string[] => {
 };
 
 export const getUrlPrefixOption = (): string => {
-  return core.getInput('url_prefix');
+  const urlPrefix = core.getInput('url_prefix');
+  // Default to ~, the default in the CLI.
+  if (!urlPrefix) {
+    return '~';
+  }
+  return urlPrefix;
 };


### PR DESCRIPTION
Right now, if you don't set url_prefix, it'll set url_prefix to ``, instead of falling back to the sentry-cli's default of `~`.

I couldn't get uploaded sourcemaps working for the life of me using this action but this fixed it. I understand why now, but it took a bit of yak shaving. Hopefully this saves time for other folks that are using defaults 😄 