### PR TITLE
[Doc] Write example for Self-Hosted Sentry

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,13 @@ The following are all _required_.
         version: 'v1.0.1'
     ```
 
+- Create a new Sentry release for [Self-Hosted Sentry](https://develop.sentry.dev/self-hosted/)
+    ```yaml
+    - uses: getsentry/action-release@v1
+      env:
+        SENTRY_URL: https://sentry.example.com/
+    ```
+
 ## Troubleshooting
 Suggestions and issues can be posted on the repository's 
 [issues page](https://github.com/getsentry/action-release/issues).

--- a/README.md
+++ b/README.md
@@ -30,19 +30,20 @@ Adding the following to your workflow will create a new Sentry release and tell 
     SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
     SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
     SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+    # SENTRY_URL: https://sentry.io/
   with:
     environment: production
 ```
 
 ### Inputs
 #### Environment Variables
-The following are all _required_.
+|name|description|default|
+|---|---|---|
+|`SENTRY_AUTH_TOKEN`|**[Required]** Authentication token for Sentry. See [installation](#create-a-sentry-internal-integration).|-|
+|`SENTRY_ORG`|**[Required]** The slug of the organization name in Sentry.|-|
+|`SENTRY_PROJECT`|The slug of the project name in Sentry. One of `SENTRY_PROJECT` or `projects` is required.|-|
+|`SENTRY_URL`|The URL used to connect to Sentry. (Only required for [Self-Hosted Sentry](https://develop.sentry.dev/self-hosted/))|`https://sentry.io/`|
 
-|name|description|
-|---|---|
-|`SENTRY_AUTH_TOKEN`|Authentication token for Sentry. See [installation](#create-a-sentry-internal-integration).|
-|`SENTRY_ORG`|The slug of the organization name in Sentry.|
-|`SENTRY_PROJECT`|The slug of the project name in Sentry.|
 #### Parameters
 |name|description|default|
 |---|---|---|


### PR DESCRIPTION
I am using Self-Hosted Sentry. 

README didn't include instructions for creating a release on Self-Hosted Sentry, so I have added them.

ref. https://docs.sentry.io/product/cli/configuration/#configuration-file