### PR TITLE
ref: New package version to indicate the beginning of a new release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "action-release",
-  "version": "1.1.6",
+  "version": "1.2.0",
   "private": true,
   "description": "GitHub Action for creating a release on Sentry",
   "main": "dist/index.js",


### PR DESCRIPTION
This does not actually make a release but when making a release we will make reference to this commit.

Since it is not a security release we will tag it as a minor update.

Release draft:
<img width="824" alt="image" src="https://user-images.githubusercontent.com/44410/179601220-b954fd29-80a0-44fa-a339-6ca90f005d62.png">
