### PR TITLE
feat: Add link to new release issue creation

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -11,16 +11,16 @@ You can see the action released in [here](https://github.com/marketplace/actions
 
 Checklist for a new release:
 
-[ ] Create a PR that bumps the version in `package.json`
-    [ ] Tag the sha with the same version `git tag _some_version_`
-    [ ] If it's a security update, tag is a patch release
-    [ ] If it's just some improvements or bug fix, tag is a minor release
-    [ ] If there are _breaking_ changes, tag it as a major release
-        [ ] Plan to do a blog post
-[ ] Once merged, visit the [releases page](https://github.com/getsentry/action-release/releases)
-    [ ] Create a new release
-    [ ] Mark it as _pre-release_ if you do not want users to start using it immediately
-    [ ] Name the release (You can use the version number if you want)
-    [ ] Describe the release by looking at what commits landed on master since the last release
-[ ] Once published, visit [the marketplace](https://github.com/marketplace/actions/sentry-release) to see that the release is showing up
-[ ] If you marked the release as _pre-release_, make sure that you do your testing and don't forget to fully release it
+- [ ] Create a PR that bumps the version in `package.json`
+  - [ ] Tag the sha with the same version `git tag _some_version_`
+- [ ] If it's a security update, tag is a patch release
+  - [ ] If it's just some improvements or bug fix, tag is a minor release
+  - [ ] If there are _breaking_ changes, tag it as a major release
+    - [ ] Plan to do a blog post
+- [ ] Once merged, visit the [releases page](https://github.com/getsentry/action-release/releases)
+  - [ ] Create a new release
+  - [ ] Mark it as _pre-release_ if you do not want users to start using it immediately
+  - [ ] Name the release (You can use the version number if you want)
+  - [ ] Describe the release by looking at what commits landed on master since the last release
+- [ ] Once published, visit [the marketplace](https://github.com/marketplace/actions/sentry-release) to see that the release is showing up
+- [ ] If you marked the release as _pre-release_, make sure that you do your testing and don't forget to fully release it

--- a/README.md
+++ b/README.md
@@ -135,6 +135,10 @@ Otherwise it could fail at the `propose-version` step with the message:
         fetch-depth: 0
     ```
 
+## Releases
+
+Open a [new release checklist issue](https://github.com/getsentry/action-release/issues/new?assignees=&labels=&template=release-checklist.md&title=New+release+checklist+for+%5Bversion+number%5D) and follow the steps in there.
+
 ## Contributing
 
 See the [Contributing Guide](https://github.com/getsentry/action-release/blob/master/CONTRIBUTING).


### PR DESCRIPTION
In order to make sure that we follow all steps to create a release I've created a new template and this makes reference to it.

I've merged the template to `master` without thinking about it. Please have a look at it and let me know if you want some tweaks:
https://github.com/getsentry/action-release/commit/8b4720d3d1512cfb105c59518acd3bd52c6323e6