### PR TITLE
feat: Add bug report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,27 @@
+---
+name: 🐞 Bug Report
+about: Report a bug in this repo
+---
+# Github Sentry Action Release Bug Report
+
+## Environment
+
+How do you use this action?
+Standard Github runners or self-hosted runners (which OS and arch?)
+
+Which version of the action?
+e.g: v1
+
+## Steps to Reproduce
+
+1. What
+2. you
+3. did.
+
+## Expected Result
+
+What you thought would happen.
+
+## Actual Result
+
+What actually happened. Maybe a screenshot/recording? Maybe some logs?


### PR DESCRIPTION
Since we defined our own release checklist template, we don't get the default org-level bug report template.