### PR TITLE
feat: implement 'working-directory' argument

### DIFF
--- a/.github/actions/use-local-dockerfile/action.yml
+++ b/.github/actions/use-local-dockerfile/action.yml
@@ -1,12 +1,16 @@
 name: "Use local Dockerfile"
 description: "Use the local Dockerfile to test the action instead of the one on DockerHub"
-
+inputs:
+  working_directory:
+    description: 'Directory to manipulate Dockerfile in'
+    required: true
+    default: '.'
 runs:
   using: "composite"
   steps:
     - name: Replace image on action.yml
       shell: bash
       run: |
-        mv action.yml previous.yml
-        sed "s|docker://ghcr.io/getsentry/action-release-image:latest|Dockerfile|" previous.yml >> action.yml
-        grep "image" action.yml
+        mv ${{inputs.working_directory}}/action.yml ${{inputs.working_directory}}/previous.yml
+        sed "s|docker://ghcr.io/getsentry/action-release-image:latest|Dockerfile|" ${{inputs.working_directory}}/previous.yml >> ${{inputs.working_directory}}/action.yml
+        grep "image" ${{inputs.working_directory}}/action.yml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
       with:
         path: test/
 
-    - uses: './.github/actions/use-local-dockerfile'
+    - uses: 'main/.github/actions/use-local-dockerfile'
       with:
         working_directory: main
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
       with:
         path: test/
 
-    - uses: 'main/.github/actions/use-local-dockerfile'
+    - uses: './main/.github/actions/use-local-dockerfile'
       with:
         working_directory: main
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,15 +23,27 @@ jobs:
       with:
         environment: production
 
-    - name: Checkout into a subdirectory
+  mock-release-working-directory:
+    name: Checkout directory we'll be running from
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        path: main/
+
+    - name: Checkout directory we'll be testing
       uses: actions/checkout@v3
       with:
-        path: _test_subdirectory
+        path: test/
 
-    - name: Mock creating a Sentry release in a subdirectory
-      uses: ./
+    - uses: './.github/actions/use-local-dockerfile'
+      with:
+        working_directory: main
+
+    - name: Mock creating a Sentry release in a different directory
+      uses: ./main
       env:
         MOCK: true
       with:
         environment: production
-        working_directory: _test_subdirectory/
+        working_directory: ./test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,3 +22,16 @@ jobs:
         MOCK: true
       with:
         environment: production
+
+    - name: Checkout into a subdirectory
+      uses: actions/checkout@v3
+      with:
+        path: _test_subdirectory
+
+    - name: Mock creating a Sentry release in a subdirectory
+      uses: ./
+      env:
+        MOCK: true
+      with:
+        environment: production
+        working_directory: _test_subdirectory/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,10 +24,11 @@ jobs:
         environment: production
 
   mock-release-working-directory:
-    name: Checkout directory we'll be running from
+    name: "Build image & mock a release in a different working directory"
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - name: Checkout directory we'll be running from
+      uses: actions/checkout@v3
       with:
         path: main/
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Adding the following to your workflow will create a new Sentry release and tell 
 |`projects`|Space-separated list of paths of projects. When omitted, falls back to the environment variable `SENTRY_PROJECT` to determine the project.|-|
 |`url_prefix`|Adds a prefix to source map urls after stripping them.|-|
 |`strip_common_prefix`|Will remove a common prefix from uploaded filenames. Useful for removing a path that is build-machine-specific.|`false`|
+|`working_directory`|Directory to collect sentry release information from. Useful when collecting information from a non-standard checkout directory.|-|
 
 ### Examples
 

--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,9 @@ inputs:
   strip_common_prefix:
     description: 'Will remove a common prefix from uploaded filenames. Useful for removing a path that is build-machine-specific.'
     required: false
+  working_directory:
+    description: 'Directory to collect sentry release information from. Useful when collecting information from a non-standard checkout directory.'
+    required: false
 runs:
   using: 'docker'
   # If you change this, update the use-local-dockerfile action

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import * as core from '@actions/core';
 import {getCLI} from './cli';
 import * as options from './options';
+import * as process from 'process';
 
 (async () => {
   try {
@@ -23,9 +24,15 @@ import * as options from './options';
       false
     );
     const version = await options.getVersion();
+    const workingDirectory = options.getWorkingDirectory();
 
     core.debug(`Version is ${version}`);
     await cli.new(version, {projects});
+
+    const currentWorkingDirectory = process.cwd();
+    if (workingDirectory !== null && workingDirectory.length > 0) {
+      process.chdir(workingDirectory);
+    }
 
     if (setCommitsOption !== 'skip') {
       core.debug(`Setting commits with option '${setCommitsOption}'`);
@@ -64,6 +71,10 @@ import * as options from './options';
     core.debug(`Finalizing the release`);
     if (shouldFinalize) {
       await cli.finalize(version);
+    }
+
+    if (workingDirectory !== null && workingDirectory.length > 0) {
+      process.chdir(currentWorkingDirectory);
     }
 
     core.debug(`Done`);

--- a/src/options.ts
+++ b/src/options.ts
@@ -165,3 +165,7 @@ export const getProjects = (): string[] => {
 export const getUrlPrefixOption = (): string => {
   return core.getInput('url_prefix');
 };
+
+export const getWorkingDirectory = (): string => {
+  return core.getInput('working_directory');
+};


### PR DESCRIPTION
When running the action-release Github Action, occasionally one might need to perform auto-detection of associated commits in a directory other than the job's working directory, such as in the case where an action performs multiple checkouts. As Github Actions do not, by default, support the ability to run an action in any directory other than the job's working directory, this change implements an argument for specifying which directory to gather sentry release information from.

Implements #117 .