### PR TITLE
feat: Add option to set `dist` on sourcemaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Adding the following to your workflow will create a new Sentry release and tell 
 |`ignore_missing`|When the flag is set and the previous release commit was not found in the repository, will create a release with the default commits count instead of failing the command.|`false`|
 |`ignore_empty`|When the flag is set, command will not fail and just exit silently if no new commits for a given release have been found.|`false`|
 |`sourcemaps`|Space-separated list of paths to JavaScript sourcemaps. Omit to skip uploading sourcemaps.|-|
+|`dist`|Unique identifier for the distribution, used to further segment your release. Usually your build number. _Note: Required when uploading sourcemaps._|-|
 |`started_at`|Unix timestamp of the release start date. Omit for current time.|-|
 |`version`|Identifier that uniquely identifies the releases. _Note: the `refs/tags/` prefix is automatically stripped when `version` is `github.ref`._|<code>${{&nbsp;github.sha&nbsp;}}</code>|
 |`version_prefix`|Value prepended to auto-generated version. For example "v".|-|
@@ -79,6 +80,7 @@ Adding the following to your workflow will create a new Sentry release and tell 
       with:
         environment: 'production'
         sourcemaps: './lib'
+        dist: ${{ github.sha }}
     ```
 
 - Create a new Sentry release for the `production` environment of your project at version `v1.0.1`.

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -72,8 +72,8 @@ describe('options', () => {
       delete process.env['INPUT_DIST'];
     });
 
-    test('should return undefined when dist is omitted', async () => {
-      expect(getDist()).toBeUndefined();
+    test('should return null when dist is omitted', async () => {
+      expect(getDist()).toBeNull();
     });
 
     test('should return a string when dist is provided', () => {

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import * as process from 'process';
 import {
   getBooleanOption,
+  getDist,
   getSourcemaps,
   getStartedAt,
   getVersion,
@@ -63,6 +64,21 @@ describe('options', () => {
     test('should return array when sourcemaps is false', () => {
       process.env['INPUT_SOURCEMAPS'] = './lib';
       expect(getSourcemaps()).toEqual(['./lib']);
+    });
+  });
+
+  describe('getDist', () => {
+    afterEach(() => {
+      delete process.env['INPUT_DIST'];
+    });
+
+    test('should return undefined when dist is omitted', async () => {
+      expect(getDist()).toBeUndefined();
+    });
+
+    test('should return a string when dist is provided', () => {
+      process.env['INPUT_DIST'] = 'foo-dist';
+      expect(getDist()).toEqual('foo-dist');
     });
   });
 

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,9 @@ inputs:
   sourcemaps:
     description: 'Space-separated list of paths to JavaScript sourcemaps. Omit to skip uploading sourcemaps.'
     required: false
+  dist:
+    description: 'Unique identifier for the distribution, used to further segment your release. Usually your build number.'
+    required: false
   finalize:
     description: 'When false, omit marking the release as finalized and released.'
     default: true

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,7 @@ import * as options from './options';
 
     const environment = options.getEnvironment();
     const sourcemaps = options.getSourcemaps();
+    const dist = options.getDist();
     const shouldFinalize = options.getBooleanOption('finalize', true);
     const ignoreMissing = options.getBooleanOption('ignore_missing', false);
     const ignoreEmpty = options.getBooleanOption('ignore_empty', false);
@@ -45,6 +46,7 @@ import * as options from './options';
           const sourceMapOptions = {
             include: sourcemaps,
             projects: localProjects,
+            dist,
             urlPrefix,
             stripCommonPrefix,
           };

--- a/src/options.ts
+++ b/src/options.ts
@@ -82,6 +82,19 @@ export const getSourcemaps = (): string[] => {
 };
 
 /**
+ * Dist is optional, but should be a string when provided.
+ * @returns string
+ */
+export const getDist = (): string | undefined => {
+  const distOption: string = core.getInput('dist');
+  if (!distOption) {
+    return undefined;
+  }
+
+  return distOption;
+};
+
+/**
  * Fetch boolean option from input. Throws error if option value is not a boolean.
  * @param input string
  * @param defaultValue boolean

--- a/src/options.ts
+++ b/src/options.ts
@@ -85,7 +85,7 @@ export const getSourcemaps = (): string[] => {
  * Dist is optional, but should be a string when provided.
  * @returns string
  */
-export const getDist = (): string | undefined => {
+export const getDist = (): string | null => {
   const distOption: string = core.getInput('dist');
   if (!distOption) {
     return null;

--- a/src/options.ts
+++ b/src/options.ts
@@ -88,7 +88,7 @@ export const getSourcemaps = (): string[] => {
 export const getDist = (): string | undefined => {
   const distOption: string = core.getInput('dist');
   if (!distOption) {
-    return undefined;
+    return null;
   }
 
   return distOption;


### PR DESCRIPTION
Adds support for `dist` as input value for GitHub Action:

```yaml
    - uses: getsentry/action-release@v1
      with:
        environment: 'production'
        sourcemaps: './lib'
        dist: ${{ github.sha }}
```

Note that this repo uses `@sentry/cli@^1.67.2` and there is a related fix in `2.3.1`:

> fix: move dist option to SentryCliUploadSourceMapsOptions (#1269) by @ikenfin
> [changelog](https://github.com/getsentry/sentry-cli/blob/master/CHANGELOG.md#231)

The above `sentry-cli` fix was to move the `dist` option from being under `SentryCliOptions` (incorrect) to be under `SentryCliUploadSourceMapsOptions` (correct)

This does not affect the GH action as those types are not referenced directly by the action.

Have not added tests for the value being passed to the CLI as that doesn't appear to be covered for any of the existing values. Did manually debug and ensure that the resulting `execute` call included the `--dist fake-dist` param.

---

**Before: Sentry UI showing dist 'none' for sourcemap artifacts**
<img width="1191" alt="Screen Shot 2023-02-24 at 12 10 23 PM" src="https://user-images.githubusercontent.com/153077/221053463-c6d0ffbd-4a7e-4109-b701-cbce5a59c0cb.png">

---

**After: Sentry UI showing SHA as the dist for sourcemaps (as passed to action):**
<img width="1184" alt="Screen Shot 2023-02-24 at 12 20 57 PM" src="https://user-images.githubusercontent.com/153077/221053649-9f7a9793-5274-4fa4-8aa6-17dc68dfe3f5.png">


Resolves getsentry/action-release#74