### PR TITLE
fix: dist option should be undefined if not specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Adding the following to your workflow will create a new Sentry release and tell 
 |`ignore_missing`|When the flag is set and the previous release commit was not found in the repository, will create a release with the default commits count instead of failing the command.|`false`|
 |`ignore_empty`|When the flag is set, command will not fail and just exit silently if no new commits for a given release have been found.|`false`|
 |`sourcemaps`|Space-separated list of paths to JavaScript sourcemaps. Omit to skip uploading sourcemaps.|-|
-|`dist`|Unique identifier for the distribution, used to further segment your release. Usually your build number. _Note: Required when uploading sourcemaps._|-|
+|`dist`|Unique identifier for the distribution, used to further segment your release. Usually your build number.|-|
 |`started_at`|Unix timestamp of the release start date. Omit for current time.|-|
 |`version`|Identifier that uniquely identifies the releases. _Note: the `refs/tags/` prefix is automatically stripped when `version` is `github.ref`._|<code>${{&nbsp;github.sha&nbsp;}}</code>|
 |`version_prefix`|Value prepended to auto-generated version. For example "v".|-|
@@ -81,7 +81,6 @@ Adding the following to your workflow will create a new Sentry release and tell 
       with:
         environment: 'production'
         sourcemaps: './lib'
-        dist: ${{ github.sha }}
     ```
 
 - Create a new Sentry release for the `production` environment of your project at version `v1.0.1`.

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -73,7 +73,7 @@ describe('options', () => {
     });
 
     test('should return null when dist is omitted', async () => {
-      expect(getDist()).toBeNull();
+      expect(getDist()).toBeUndefined();
     });
 
     test('should return a string when dist is provided', () => {

--- a/src/options.ts
+++ b/src/options.ts
@@ -85,10 +85,10 @@ export const getSourcemaps = (): string[] => {
  * Dist is optional, but should be a string when provided.
  * @returns string
  */
-export const getDist = (): string | null => {
+export const getDist = (): string | undefined => {
   const distOption: string = core.getInput('dist');
   if (!distOption) {
-    return null;
+    return undefined;
   }
 
   return distOption;


### PR DESCRIPTION
In #125, we added support for using `dist` with sourcemaps, however, we return `null` when not specified and that gets converted into the string `"null"` down the pipeline which has broken the sourcemaps for various customers in the last two weeks.

Also, ss indicated in #138, `dist` is optional for sourcemaps when used with the CLI. Updating the README.me to handle it.

This also removes a warning which shows when the action is run:
```
Warning: Unexpected input(s) 'dist', valid inputs are ['entryPoint', 'args', 'environment', 'sourcemaps', 'finalize', 'ignore_missing', 'ignore_empty', 'started_at', 'version', 'version_prefix',
'set_commits', 'projects', 'url_prefix', 'strip_common_prefix', 'working_directory']
```

Fixes #140