### PR TITLE
fix(ci): Allow create default set of commits

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,10 +3,6 @@ on:
   push:
     branches:
       - master
-  # XXX: temp change
-  pull_request:
-    paths-ignore:
-      - '**.md'
 env:
   # Variables defined in the repository
   SENTRY_ORG: ${{ vars.SENTRY_ORG }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,10 @@ on:
   push:
     branches:
       - master
+  # XXX: temp change
+  pull_request:
+    paths-ignore:
+      - '**.md'
 env:
   # Variables defined in the repository
   SENTRY_ORG: ${{ vars.SENTRY_ORG }}
@@ -60,3 +64,4 @@ jobs:
         SENTRY_LOG_LEVEL: debug
       with:
         environment: 'production'
+        ignore_missing: true


### PR DESCRIPTION
You can see this PR working [here](https://github.com/getsentry/action-release/actions/runs/4833388053/jobs/8613330988?pr=155).

If the action executes and there's never been a release before, it will fail. Adding `ignore_missing` fixes it:
```
When the flag is set and the previous release commit was not found in the repository, will create a release with the default commits count instead of failing the command.
```