### PR TITLE
fix(test): Add timezone to timestamp

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -104,7 +104,7 @@ describe('options', () => {
     });
 
     test('should return an integer when started_at is an ISO8601 string.', async () => {
-      process.env['INPUT_STARTED_AT'] = '2017-07-13T19:40:00';
+      process.env['INPUT_STARTED_AT'] = '2017-07-13T19:40:00-07:00';
       expect(getStartedAt()).toEqual(1500000000);
     });
 


### PR DESCRIPTION
If the timezone isn't specified, the timestamp will be parsed depending on local time, which makes the test fail.