### PR TITLE
Make instructions for generating a token clearer

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Give your new integration a name (for example, "GitHub Action Release Integratio
 
 ![View of internal integration permissions.](images/internal-integration-permissions.png)
 
-Click “Save” at the bottom of the page and grab your token, which you’ll use as your `SENTRY_AUTH_TOKEN`. We recommend you store this as an [encrypted secret](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions).
+Click “Save” at the bottom of the page, then go back into your newly created integration and click "New Token". Grab this newly generated token and use it as your `SENTRY_AUTH_TOKEN`. We recommend you store this as an [encrypted secret](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions).
 
 ## Usage
 


### PR DESCRIPTION
A Client Secret is pre-generaterd at the bottom of the page with a copy button so it is unclear what the user needs to do.