### PR TITLE
Mention SENTRY_RELEASE environment variable in troubleshooting guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Suggestions and issues can be posted on the repository's
     Syntax error: end of file unexpected (expecting ")")
     ```
 
-- When adding the action, make sure to first checkout your repo with `actions/checkout@v3`.
+- When adding the action, make sure to first checkout your repo with `actions/checkout@v3` or provide `SENTRY_RELEASE` environment variable manually.
 Otherwise it could fail at the `propose-version` step with the message:
 
     ```text


### PR DESCRIPTION
Sometimes, checking out repository in a job that creates Sentry release is undesirable. Troubleshooting guide misguides users into thinking that checking out is unavoidable, where in reality, setting `SENTRY_RELEASE` environment variable is a viable alternative, according to the source code:

https://github.com/getsentry/sentry-cli/blame/master/src/utils/releases.rs#L89