### PR TITLE
meta(release): Bump version to 1.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "action-release",
-  "version": "1.4.1",
+  "version": "1.8.0",
   "private": true,
   "description": "GitHub Action for creating a release on Sentry",
   "main": "dist/index.js",


### PR DESCRIPTION
Note: the version change here is quite drastic because it was overlooked that we should also bump the package version here. The latest version of the action is `1.7.0`: https://github.com/marketplace/actions/sentry-release

Ref: https://github.com/getsentry/action-release/issues/216