### PR TITLE
feat(telemetry): Collect project specific tags

### DIFF
--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -25,6 +25,10 @@ export async function withTelemetry<F>(
 
   const session = Sentry.startSession();
 
+  const org = process.env['SENTRY_ORG'];
+
+  Sentry.setUser({id: org});
+  Sentry.setTag('organization', org);
   Sentry.setTag('node', process.version);
   Sentry.setTag('platform', process.platform);
 
@@ -80,15 +84,21 @@ export async function safeFlush(): Promise<void> {
 }
 
 /**
- * Determine if telemetry should be enabled
+ * Check whether the user is self-hosting Sentry.
  */
-export function isTelemetryEnabled(): boolean {
+export function isSelfHosted(): boolean {
   const url = new URL(
     process.env['SENTRY_URL'] || `https://${SENTRY_SAAS_HOSTNAME}`
   );
 
+  return url.hostname !== SENTRY_SAAS_HOSTNAME;
+}
+
+/**
+ * Determine if telemetry should be enabled.
+ */
+export function isTelemetryEnabled(): boolean {
   return (
-    !options.getBooleanOption('disable_telemetry', false) &&
-    url.hostname === SENTRY_SAAS_HOSTNAME
+    !options.getBooleanOption('disable_telemetry', false) && !isSelfHosted()
   );
 }


### PR DESCRIPTION
Collects

- `project: string` if single project is specified
- `projects: string[]` if multiple projects are specified, comma-separated
- `set-commits: 'auto' | 'skip'`
- `sourcemaps: boolean` if sourcemaps are set by the user
- `sourcemaps-uploaded: true` iff sourcemaps have been uploaded, not set otherwise
- `finalized: true` iff release has been finalized
- `organization: string` the user org

It also sets the `user.id` to the user org.

ref: https://github.com/getsentry/action-release/issues/217

Some of the tags listed in the reference issue have not been collected:

- `project id`, not available -> only project slug is collected
- `action release version` -> already collected
- `checkout action version` -> we do not have access to this
- `platform` -> we do not have access to this in the action
- `runtime` -> we do not have access to this in the action
- `os` -> we do not have access to this in the action
- `debugId` -> will be added with https://github.com/getsentry/action-release/issues/220
- `self-hosted or Saas` -> we do not enable Sentry when the project is self-hosted so this tag would always be `false/'self-hosted'`
- `parameters`: picked the ones listed above, but we can discuss adding more
- `measurements`: to be looked into, might require extra api calls.
