### PR TITLE
feat(sourcemaps): Add `inject` option to inject debug ids into source files and sourcemaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,23 +71,24 @@ Adding the following to your workflow will create a new Sentry release and tell 
 
 #### Parameters
 
-|name|description|default|
-|---|---|---|
-|`environment`|Set the environment for this release. E.g. "production" or "staging". Omit to skip adding deploy to release.|-|
-|`finalize`|When false, omit marking the release as finalized and released.|`true`|
-|`ignore_missing`|When the flag is set and the previous release commit was not found in the repository, will create a release with the default commits count instead of failing the command.|`false`|
-|`ignore_empty`|When the flag is set, command will not fail and just exit silently if no new commits for a given release have been found.|`false`|
-|`sourcemaps`|Space-separated list of paths to JavaScript sourcemaps. Omit to skip uploading sourcemaps.|-|
-|`dist`|Unique identifier for the distribution, used to further segment your release. Usually your build number.|-|
-|`started_at`|Unix timestamp of the release start date. Omit for current time.|-|
-|`version`|Identifier that uniquely identifies the releases. _Note: the `refs/tags/` prefix is automatically stripped when `version` is `github.ref`._|<code>${{&nbsp;github.sha&nbsp;}}</code>|
-|`version_prefix`|Value prepended to auto-generated version. For example "v".|-|
-|`set_commits`|Specify whether to set commits for the release. Either "auto" or "skip".|"auto"|
-|`projects`|Space-separated list of paths of projects. When omitted, falls back to the environment variable `SENTRY_PROJECT` to determine the project.|-|
-|`url_prefix`|Adds a prefix to source map urls after stripping them.|-|
-|`strip_common_prefix`|Will remove a common prefix from uploaded filenames. Useful for removing a path that is build-machine-specific.|`false`|
-|`working_directory`|Directory to collect sentry release information from. Useful when collecting information from a non-standard checkout directory.|-|
-|`disable_telemetry`|The action sends telemetry data and crash reports to Sentry. This helps us improve the action. You can turn this off by setting this flag.|`false`|
+|name| description                                                                                                                                                                |default|
+|---|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---|
+|`environment`| Set the environment for this release. E.g. "production" or "staging". Omit to skip adding deploy to release.                                                               |-|
+|`inject`| Injects Debug IDs into source files and sourcemaps. We **strongly recommend** enabling this to ensure proper un-minifaction of your stacktraces.                           |`false`|
+|`sourcemaps`| Space-separated list of paths to JavaScript sourcemaps. Omit to skip uploading sourcemaps.                                                                                 |-|
+|`finalize`| When false, omit marking the release as finalized and released.                                                                                                            |`true`|
+|`ignore_missing`| When the flag is set and the previous release commit was not found in the repository, will create a release with the default commits count instead of failing the command. |`false`|
+|`ignore_empty`| When the flag is set, command will not fail and just exit silently if no new commits for a given release have been found.                                                  |`false`|
+|`dist`| Unique identifier for the distribution, used to further segment your release. Usually your build number.                                                                   |-|
+|`started_at`| Unix timestamp of the release start date. Omit for current time.                                                                                                           |-|
+|`version`| Identifier that uniquely identifies the releases. _Note: the `refs/tags/` prefix is automatically stripped when `version` is `github.ref`._                                |<code>${{&nbsp;github.sha&nbsp;}}</code>|
+|`version_prefix`| Value prepended to auto-generated version. For example "v".                                                                                                                |-|
+|`set_commits`| Specify whether to set commits for the release. Either "auto" or "skip".                                                                                                   |"auto"|
+|`projects`| Space-separated list of paths of projects. When omitted, falls back to the environment variable `SENTRY_PROJECT` to determine the project.                                 |-|
+|`url_prefix`| Adds a prefix to source map urls after stripping them.                                                                                                                     |-|
+|`strip_common_prefix`| Will remove a common prefix from uploaded filenames. Useful for removing a path that is build-machine-specific.                                                            |`false`|
+|`working_directory`| Directory to collect sentry release information from. Useful when collecting information from a non-standard checkout directory.                                           |-|
+|`disable_telemetry`| The action sends telemetry data and crash reports to Sentry. This helps us improve the action. You can turn this off by setting this flag.                                 |`false`|
 
 ### Examples
 

--- a/README.md
+++ b/README.md
@@ -100,13 +100,14 @@ Adding the following to your workflow will create a new Sentry release and tell 
 
 ### Examples
 
-- Create a new Sentry release for the `production` environment and upload JavaScript source maps from the `./lib` directory.
+- Create a new Sentry release for the `production` environment, inject Debug IDs into JavaScript source files and sourcemaps and upload them from the `./dist` directory.
 
     ```yaml
     - uses: getsentry/action-release@v1
       with:
         environment: 'production'
-        sourcemaps: './lib'
+        inject: true
+        sourcemaps: './dist'
     ```
 
 - Create a new Sentry release for the `production` environment of your project at version `v1.0.1`.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,14 @@ A release is a version of your code that can be deployed to an environment. When
 
 Additionally, releases are used for applying [source maps](https://docs.sentry.io/platforms/javascript/sourcemaps/) to minified JavaScript to view original, untransformed source code. You can learn more about releases in the [releases documentation](https://docs.sentry.io/workflow/releases).
 
+## What's new
+
+* **feat(sourcemaps): Add inject option to inject debug ids into source files and sourcemaps**
+
+A new option to inject Debug IDs into source files and sourcemaps was added to the action to ensure proper un-minifaction of your stacktraces. We **strongly recommend enabling** this by setting `inject: true` in your action alongside providing a path to sourcemaps.
+
+Please refer to the [release page](https://github.com/getsentry/action-release/releases) for the latest release notes.
+
 ## Prerequisites
 
 ### Create an Organization Auth Token
@@ -43,7 +51,7 @@ Adding the following to your workflow will create a new Sentry release and tell 
 > Make sure you are using at least v3 of [actions/checkout](https://github.com/actions/checkout) with `fetch-depth: 0`, issues commonly occur with older versions.
  
 ```yaml
-- uses: actions/checkout@v3
+- uses: actions/checkout@v4
   with:
     fetch-depth: 0
 
@@ -74,7 +82,7 @@ Adding the following to your workflow will create a new Sentry release and tell 
 |name| description                                                                                                                                                                |default|
 |---|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---|
 |`environment`| Set the environment for this release. E.g. "production" or "staging". Omit to skip adding deploy to release.                                                               |-|
-|`inject`| Injects Debug IDs into source files and sourcemaps. We **strongly recommend** enabling this to ensure proper un-minifaction of your stacktraces.                           |`false`|
+|`inject`| Injects Debug IDs into source files and sourcemaps. We **strongly recommend enabling** this to ensure proper un-minifaction of your stacktraces.                           |`false`|
 |`sourcemaps`| Space-separated list of paths to JavaScript sourcemaps. Omit to skip uploading sourcemaps.                                                                                 |-|
 |`finalize`| When false, omit marking the release as finalized and released.                                                                                                            |`true`|
 |`ignore_missing`| When the flag is set and the previous release commit was not found in the repository, will create a release with the default commits count instead of failing the command. |`false`|

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ A new option to inject Debug IDs into source files and sourcemaps was added to t
 
 Please refer to the [release page](https://github.com/getsentry/action-release/releases) for the latest release notes.
 
+[Learn more about debug ids](https://docs.sentry.io/platforms/javascript/sourcemaps/troubleshooting_js/artifact-bundles/)
 ## Prerequisites
 
 ### Create an Organization Auth Token

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,9 @@ inputs:
   environment:
     description: 'Set the environment for this release. E.g. "production" or "staging". Omit to skip adding deploy to release.'
     required: false
+  inject:
+    description: 'Injects Debug IDs into source files and sourcemaps. We strongly recommend enabling this to ensure proper un-minifaction of your stacktraces.'
+    required: false
   sourcemaps:
     description: 'Space-separated list of paths to JavaScript sourcemaps. Omit to skip uploading sourcemaps.'
     required: false

--- a/docs/publishing-a-release.md
+++ b/docs/publishing-a-release.md
@@ -5,7 +5,6 @@ The [build.yml](../.github/workflows/build.yml) workflow will build a Docker ima
 > [!WARNING]
 > Merging pull requests into `master` means changes are live for anyone who uses the action regardless of bumping the version.
 > Be extremely careful and intentional with changes and ensure properly testing them before merging, see [#Testing](development.md#testing) for more info.
-effectively being live for everyone even if we do not bump the version.
 
 > [!NOTE]
 > Unfortunately, we only use the `latest` tag for the Docker image, thus, making use of a version with the action ineffective (e.g. `v1` vs `v1.3.0`). 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "action-release",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "private": true,
   "description": "GitHub Action for creating a release on Sentry",
   "main": "dist/index.js",


### PR DESCRIPTION
`inject` is off by default in this version. We are considering making it opt-out by default in the near future.

Closes: #220

<hr>

From my manual test run:

![Screenshot 2025-01-14 at 12 25 24@2x](https://github.com/user-attachments/assets/5c203079-b6bb-4e63-8112-67f8cf2ed6eb)

![Screenshot 2025-01-14 at 12 22 59@2x](https://github.com/user-attachments/assets/269e5626-6f6b-47cc-be1f-b8abe987336c)
