### PR TITLE
chore(release): Add craft publish workflow

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -1,0 +1,15 @@
+minVersion: 0.23.1
+changelogPolicy: auto
+preReleaseCommand: bash scripts/craft-pre-release.sh
+targets:
+  - id: release
+    name: docker
+    source: ghcr.io/getsentry/action-release-image
+    target: getsentry/action-release
+  - id: latest
+    name: docker
+    source: ghcr.io/getsentry/action-release-image
+    target: getsentry/sentry
+    targetFormat: '{{{target}}}:latest'
+  - name: github
+    tagPrefix: v

--- a/.github/actions/use-local-dockerfile/action.yml
+++ b/.github/actions/use-local-dockerfile/action.yml
@@ -12,5 +12,5 @@ runs:
       shell: bash
       run: |
         mv ${{inputs.working_directory}}/action.yml ${{inputs.working_directory}}/previous.yml
-        sed "s|docker://ghcr.io/getsentry/action-release-image:latest|Dockerfile|" ${{inputs.working_directory}}/previous.yml >> ${{inputs.working_directory}}/action.yml
+        sed "s|docker://ghcr.io/getsentry/action-release-image:.*[^']|Dockerfile|" ${{inputs.working_directory}}/previous.yml >> ${{inputs.working_directory}}/action.yml
         grep "image" ${{inputs.working_directory}}/action.yml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,19 +3,12 @@ on:
   push:
     branches:
       - master
-
-env:
-  # Variables defined in the repository
-  SENTRY_ORG: ${{ vars.SENTRY_ORG }}
-  # For master we have an environment variable that selects the action-release project
-  # instead of action-release-prs
-  # For other branches: https://sentry-ecosystem.sentry.io/releases/?project=4505075304693760
-  # For master branch: https://sentry-ecosystem.sentry.io/releases/?project=6576594
-  SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
+      - release/**
+  pull_request:
 
 jobs:
   docker-build:
-    name: Build & pubish Docker images
+    name: Build & publish Docker images
     runs-on: ubuntu-latest
     permissions:
       packages: write
@@ -23,9 +16,9 @@ jobs:
       matrix:
         target:
           - name: builder
-            image: action-release-builder-image:latest
+            image: action-release-builder-image
           - name: app
-            image: action-release-image:latest
+            image: action-release-image
     steps:
     - name: Checkout repo
       uses: actions/checkout@v3
@@ -56,20 +49,8 @@ jobs:
       uses: docker/build-push-action@v6
       with:
         platforms: linux/amd64,linux/arm64
-        push: ${{ github.ref == 'refs/heads/master' }}
-        tags: ghcr.io/${{ github.repository_owner }}/${{ matrix.target.image }}
-        cache-from: ghcr.io/${{ github.repository_owner }}/${{ matrix.target.image }}
+        push: true
+        tags: ghcr.io/${{ github.repository_owner }}/${{ matrix.target.image }}:${{ github.sha }}
+        cache-from: ghcr.io/${{ github.repository_owner }}/${{ matrix.target.image }}:latest
         target: ${{ matrix.target.name }}
         build-args: BUILDKIT_INLINE_CACHE=1
-
-    # This step creates real Sentry releases for the action itself:
-    # https://sentry-ecosystem.sentry.io/releases/?project=6576594
-    - name: Sentry Release
-      uses: getsentry/action-release@v1
-      if: vars.SENTRY_ORG != ''
-      env:
-        SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-        SENTRY_LOG_LEVEL: debug
-      with:
-        environment: 'production'
-        ignore_missing: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+name: "Action: Prepare Release"
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version to release
+        required: true
+      force:
+        description: Force a release even when there are release-blockers (optional)
+        required: false
+      merge_target:
+        description: Target branch to merge into. Uses the default branch as a fallback (optional)
+        required: false
+        default: master
+jobs:
+  release:
+    runs-on: ubuntu-20.04
+    name: 'Release a new version'
+    steps:
+      - name: Get auth token
+        id: token
+        uses: actions/create-github-app-token@5d869da34e18e7287c1daad50e0b8ea0f506ce69 # v1.11.0
+        with:
+          app-id: ${{ vars.SENTRY_RELEASE_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.SENTRY_RELEASE_BOT_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ steps.token.outputs.token }}
+          fetch-depth: 0
+
+      - name: Prepare release
+        uses: getsentry/action-prepare-release@v1
+        env:
+          GITHUB_TOKEN: ${{ steps.token.outputs.token }}
+        with:
+          version: ${{ github.event.inputs.version }}
+          force: ${{ github.event.inputs.force }}
+          merge_target: ${{ github.event.inputs.merge_target }}
+          craft_config_from_merge_target: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,4 +37,3 @@ jobs:
           version: ${{ github.event.inputs.version }}
           force: ${{ github.event.inputs.force }}
           merge_target: ${{ github.event.inputs.merge_target }}
-          craft_config_from_merge_target: true

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,11 +1,18 @@
 {
-    "printWidth": 80,
-    "tabWidth": 2,
-    "useTabs": false,
-    "semi": true,
-    "singleQuote": true,
-    "trailingComma": "es5",
-    "bracketSpacing": false,
-    "arrowParens": "avoid",
-    "parser": "typescript"
-  }
+  "printWidth": 80,
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "es5",
+  "bracketSpacing": false,
+  "arrowParens": "avoid",
+  "overrides": [
+    {
+      "files": "*.md",
+      "options": {
+        "proseWrap": "preserve"
+      }
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+## Unreleased
+
+
+## 1.9.0
+
+** Important Changes **
+
+- **feat(sourcemaps): Add inject option to inject debug ids into source files and sourcemaps (#229) **
+A new option to inject Debug IDs into source files and sourcemaps was added to the action to ensure proper un-minifaction of your stacktraces. We strongly recommend enabling this by setting inject: true in your action alongside providing a path to sourcemaps.
+
+** Other Changes **
+- feat(telemetry): Collect project specific tags (#228)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,7 @@ A new option to inject Debug IDs into source files and sourcemaps was added to t
 
 ** Other Changes **
 - feat(telemetry): Collect project specific tags (#228)
+
+## Previous Releases
+
+For previous releases, check the [Github Releases](https://github.com/getsentry/action-release/releases) page.

--- a/action.yml
+++ b/action.yml
@@ -52,7 +52,7 @@ inputs:
     required: false
 runs:
   using: 'docker'
-  image: 'docker://ghcr.io/getsentry/action-release-image:1.9.0'
+  image: 'docker://ghcr.io/getsentry/action-release-image:latest'
 branding:
   icon: 'triangle'
   color: 'purple'

--- a/action.yml
+++ b/action.yml
@@ -52,8 +52,7 @@ inputs:
     required: false
 runs:
   using: 'docker'
-  # If you change this, update the use-local-dockerfile action
-  image: 'docker://ghcr.io/getsentry/action-release-image:latest'
+  image: 'docker://ghcr.io/getsentry/action-release-image:1.9.0'
 branding:
   icon: 'triangle'
   color: 'purple'

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,6 +1,6 @@
 # Development of `getsentry/action-release`
 
-This document aims to provide guidelines for maintainers and contains information on how to develop and test this action. 
+This document aims to provide guidelines for maintainers and contains information on how to develop and test this action.
 For info on how to release changes, follow [publishing-a-release](publishing-a-release.md).
 
 ## Development
@@ -20,7 +20,7 @@ You can run unit tests with `yarn test`.
 The first job in [test.yml](../.github/workflows/test.yml) has instructions on how to tweak a job in order to execute your changes as part of the PR.
 
 > [!NOTE]  
-> Contributors will need to create an internal integration in their Sentry org and need to be an admin. 
+> Contributors will need to create an internal integration in their Sentry org and need to be an admin.
 > See [#Prerequisites](../README.md#prerequisites).
 
 Members of this repo will not have to set anything up since [the integration](https://sentry-ecosystem.sentry.io/settings/developer-settings/end-to-end-action-release-integration-416eb2/) is already set-up. Just open the PR and you will see [a release created](https://sentry-ecosystem.sentry.io/releases/?project=4505075304693760) for your PR.
@@ -33,11 +33,12 @@ Members of this repo will not have to set anything up since [the integration](ht
 > [!NOTE]
 > Once we start producing Docker images for PRs we can get rid of the need of using the `sed` command below.
 
-**Step 1**  
-* Create a branch, make changes and push it
-* Run this command, commit the changes and push it
-  * This will cause the action-release to be built using the `Dockerfile`
-  * You will need to revert this change once your changes are approved and ready to be merged
+**Step 1**
+
+- Create a branch, make changes and push it
+- Run this command, commit the changes and push it
+  - This will cause the action-release to be built using the `Dockerfile`
+  - You will need to revert this change once your changes are approved and ready to be merged
 
 ```shell
 sed -i .backup 's|docker://ghcr.io/getsentry/action-release-image:latest|Dockerfile|' action.yml
@@ -45,23 +46,24 @@ sed -i .backup 's|docker://ghcr.io/getsentry/action-release-image:latest|Dockerf
 
 **Step 2**  
 Test out your action-release changes on your own repo.
-* Get the sha for the latest commit on **Step 1**
-* Modify your usage of action-release to point to that commit (if you're using a fork, edit the `getsentry` org in the string below)
+
+- Get the sha for the latest commit on **Step 1**
+- Modify your usage of action-release to point to that commit (if you're using a fork, edit the `getsentry` org in the string below)
 
 Example:
 
 ```yml
-  - name: Sentry Release
-    uses: getsentry/action-release@<latest commit sha>
-    env:
-      # You will remove this in the next steps when ready
-      MOCK: true
-      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-      SENTRY_ORG: ${{ vars.SENTRY_ORG }}
-      # If you specify a GitHub environment for the branch from where you create
-      # releases from (e.g. master), you can then specify a repository-level variable
-      # for all other branches. This allows using a second project for end-to-end testing
-      SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
+- name: Sentry Release
+  uses: getsentry/action-release@<latest commit sha>
+  env:
+    # You will remove this in the next steps when ready
+    MOCK: true
+    SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+    SENTRY_ORG: ${{ vars.SENTRY_ORG }}
+    # If you specify a GitHub environment for the branch from where you create
+    # releases from (e.g. master), you can then specify a repository-level variable
+    # for all other branches. This allows using a second project for end-to-end testing
+    SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
 ```
 
 > [!NOTE]

--- a/docs/publishing-a-release.md
+++ b/docs/publishing-a-release.md
@@ -7,12 +7,12 @@ The [build.yml](../.github/workflows/build.yml) workflow will build a Docker ima
 > Be extremely careful and intentional with changes and ensure properly testing them before merging, see [#Testing](development.md#testing) for more info.
 
 > [!NOTE]
-> Unfortunately, we only use the `latest` tag for the Docker image, thus, making use of a version with the action ineffective (e.g. `v1` vs `v1.3.0`). 
+> Unfortunately, we only use the `latest` tag for the Docker image, thus, making use of a version with the action ineffective (e.g. `v1` vs `v1.3.0`).
 > See #129 on how to fix this.
 
 > [!NOTE]
-> At the moment our Docker image publishing is decoupled from `tag` creation in the repository. 
-> We should only publish a specific Docker tag when we create a tag (you can make GitHub workflows listen to this). See #102 for details. 
+> At the moment our Docker image publishing is decoupled from `tag` creation in the repository.
+> We should only publish a specific Docker tag when we create a tag (you can make GitHub workflows listen to this). See #102 for details.
 > Once this is fixed, merges to `master` will not make the Docker image live.
 
 When you are ready to make a release, open a [new release checklist issue](https://github.com/getsentry/action-release/issues/new?assignees=&labels=&template=release-checklist.md&title=New+release+checklist+for+%5Bversion+number%5D) and follow the steps in there.

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "main": "dist/index.js",
   "scripts": {
     "build": "ncc build src/main.ts",
-    "format": "prettier --write **/*.ts",
-    "format-check": "prettier --check **/*.ts",
+    "format": "prettier --write **/*.ts **/*.md",
+    "format-check": "prettier --check **/*.ts **/*.md",
     "lint": "eslint src/**/*.ts",
     "test": "jest",
     "all": "yarn run format && yarn run lint && yarn run build && yarn test"

--- a/scripts/craft-pre-release.sh
+++ b/scripts/craft-pre-release.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -eux
+
+OLD_VERSION="${1}"
+NEW_VERSION="${2}"
+DOCKER_REGISTRY_IMAGE="docker://ghcr.io/getsentry/action-release-image"
+
+# Move to the project root
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd $SCRIPT_DIR/..
+
+# Bump the npm package version
+export npm_config_git_tag_version=false
+npm version "${NEW_VERSION}"
+
+# Update the docker image tag in the action
+sed -i "s|\($DOCKER_REGISTRY_IMAGE:\)[^']*|\1$NEW_VERSION|" action.yml


### PR DESCRIPTION
Previously, any push to `master` builts and uploads the action's underlying docker image to the GitHub registry under the `latest` tag. That meant, regardless of version specified in a user's workflow they'd get the latest change.

The introduction of craft allows us to push versioned images to the registry and associate a release's action with that version.

At the moment, this workflow does not incorporate tags for major (e.g. `v1`) and major.minor (e.g. `v1.2`). The ability to publish several git tags will probably have to be added to craft or publish directly.

Closes: #129, #233