### PR TITLE
chore(release): Unset artifactProvider in craft

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -1,6 +1,8 @@
 minVersion: 0.23.1
 changelogPolicy: auto
 preReleaseCommand: bash scripts/craft-pre-release.sh
+artifactProvider:
+  name: none
 targets:
   - id: release
     name: docker


### PR DESCRIPTION
We don't publish any artifacts when releasing, everything is done via the docker registry. Not turning this off results in Craft trying to look up artifacts, example failed run: https://github.com/getsentry/publish/actions/runs/13032284844?check_suite_focus=true#step:8