### PR TITLE
fix(craft): Fix craft target to publish to github registry

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -7,11 +7,11 @@ targets:
   - id: release
     name: docker
     source: ghcr.io/getsentry/action-release-image
-    target: getsentry/action-release
+    target: ghcr.io/getsentry/action-release-image
   - id: latest
     name: docker
     source: ghcr.io/getsentry/action-release-image
-    target: getsentry/sentry
+    target: ghcr.io/getsentry/action-release-image
     targetFormat: '{{{target}}}:latest'
   - name: github
     tagPrefix: v


### PR DESCRIPTION
The targets to publish the final docker image has been wrongly defined.