### PR TITLE
fix: Ensure action's js builds after bumping version in craft-pre-release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.10.1
+
+This release contains changes concerning maintainers of the repo and has no user-facing changes.
+
 ## 1.10.0
 
 - **feat(action): Support macos and windows runners**  

--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ Additionally, releases are used for applying [source maps](https://docs.sentry.i
 
 ## What's new
 
-* **feat(sourcemaps): Add inject option to inject debug ids into source files and sourcemaps**
+### 1.10.0
 
-A new option to inject [Debug IDs](https://docs.sentry.io/platforms/javascript/sourcemaps/troubleshooting_js/artifact-bundles/) into source files and sourcemaps was added to the action to ensure proper un-minifaction of your stacktraces. We **strongly recommend enabling** this by setting `inject: true` in your action alongside providing a path to sourcemaps.
-
+- **feat(action): Support macos and windows runners**  
+We now publish a composite action that runs on all runners. Actions can now be properly versioned, allowing pinning versions from here on out.
 
 Please refer to the [release page](https://github.com/getsentry/action-release/releases) for the latest release notes.
 

--- a/scripts/craft-pre-release.sh
+++ b/scripts/craft-pre-release.sh
@@ -12,3 +12,7 @@ cd $SCRIPT_DIR/..
 # as craft/publish will take care of that
 export npm_config_git_tag_version=false
 npm version "${NEW_VERSION}"
+
+# The build output contains the package.json so we need to
+# rebuild to ensure it's reflected after bumping the version
+yarn build


### PR DESCRIPTION
Craft runs `craft-pre-release.sh` to bump the version in `package.json` but these changes are then not reflected in the checked in `dist/index.js`. We therefor need to rebuild the dist after bumping the version.