### PR TITLE
fix(ci): Use volta to ensure node and npm are available

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -55,6 +55,8 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    - uses: volta-cli/action@v4
+
     - name: Install Sentry CLI v2
       shell: bash
       run: npm install --save-dev --no-package-lock @sentry/cli@^2.4


### PR DESCRIPTION
Not all runners have npm/yarn out of the box so unfortunately we'll have to ensure both node and npm are available using volta. 

Closes: #253