### PR TITLE
fix(action): Use `action/setup-node` instead of unofficial volta action

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,24 +70,26 @@ Adding the following to your workflow will create a new Sentry release and tell 
 
 #### Parameters
 
-|name| description                                                                                                                                                                |default|
-|---|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---|
-|`environment`| Set the environment for this release. E.g. "production" or "staging". Omit to skip adding deploy to release.                                                               |-|
-|`inject`| Injects Debug IDs into source files and sourcemaps. We **strongly recommend enabling** this to ensure proper un-minifaction of your stacktraces.                           |`false`|
-|`sourcemaps`| Space-separated list of paths to JavaScript sourcemaps. Omit to skip uploading sourcemaps.                                                                                 |-|
-|`finalize`| When false, omit marking the release as finalized and released.                                                                                                            |`true`|
-|`ignore_missing`| When the flag is set and the previous release commit was not found in the repository, will create a release with the default commits count instead of failing the command. |`false`|
-|`ignore_empty`| When the flag is set, command will not fail and just exit silently if no new commits for a given release have been found.                                                  |`false`|
-|`dist`| Unique identifier for the distribution, used to further segment your release. Usually your build number.                                                                   |-|
-|`started_at`| Unix timestamp of the release start date. Omit for current time.                                                                                                           |-|
-|`version`| Identifier that uniquely identifies the releases. _Note: the `refs/tags/` prefix is automatically stripped when `version` is `github.ref`._                                |<code>${{&nbsp;github.sha&nbsp;}}</code>|
-|`version_prefix`| Value prepended to auto-generated version. For example "v".                                                                                                                |-|
-|`set_commits`| Specify whether to set commits for the release. Either "auto" or "skip".                                                                                                   |"auto"|
-|`projects`| Space-separated list of paths of projects. When omitted, falls back to the environment variable `SENTRY_PROJECT` to determine the project.                                 |-|
-|`url_prefix`| Adds a prefix to source map urls after stripping them.                                                                                                                     |-|
-|`strip_common_prefix`| Will remove a common prefix from uploaded filenames. Useful for removing a path that is build-machine-specific.                                                            |`false`|
-|`working_directory`| Directory to collect sentry release information from. Useful when collecting information from a non-standard checkout directory.                                           |-|
-|`disable_telemetry`| The action sends telemetry data and crash reports to Sentry. This helps us improve the action. You can turn this off by setting this flag.                                 |`false`|
+| name                     | description                                                                                                                                                                |default|
+|--------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---|
+| `environment`            | Set the environment for this release. E.g. "production" or "staging". Omit to skip adding deploy to release.                                                               |-|
+| `inject`                 | Injects Debug IDs into source files and sourcemaps. We **strongly recommend enabling** this to ensure proper un-minifaction of your stacktraces.                           |`false`|
+| `sourcemaps`             | Space-separated list of paths to JavaScript sourcemaps. Omit to skip uploading sourcemaps.                                                                                 |-|
+| `finalize`               | When false, omit marking the release as finalized and released.                                                                                                            |`true`|
+| `ignore_missing`         | When the flag is set and the previous release commit was not found in the repository, will create a release with the default commits count instead of failing the command. |`false`|
+| `ignore_empty`           | When the flag is set, command will not fail and just exit silently if no new commits for a given release have been found.                                                  |`false`|
+| `dist`                   | Unique identifier for the distribution, used to further segment your release. Usually your build number.                                                                   |-|
+| `started_at`             | Unix timestamp of the release start date. Omit for current time.                                                                                                           |-|
+| `version`                | Identifier that uniquely identifies the releases. _Note: the `refs/tags/` prefix is automatically stripped when `version` is `github.ref`._                                |<code>${{&nbsp;github.sha&nbsp;}}</code>|
+| `version_prefix`         | Value prepended to auto-generated version. For example "v".                                                                                                                |-|
+| `set_commits`            | Specify whether to set commits for the release. Either "auto" or "skip".                                                                                                   |"auto"|
+| `projects`               | Space-separated list of paths of projects. When omitted, falls back to the environment variable `SENTRY_PROJECT` to determine the project.                                 |-|
+| `url_prefix`             | Adds a prefix to source map urls after stripping them.                                                                                                                     |-|
+| `strip_common_prefix`    | Will remove a common prefix from uploaded filenames. Useful for removing a path that is build-machine-specific.                                                            |`false`|
+| `working_directory`      | Directory to collect sentry release information from. Useful when collecting information from a non-standard checkout directory.                                           |-|
+| `disable_telemetry`      | The action sends telemetry data and crash reports to Sentry. This helps us improve the action. You can turn this off by setting this flag.                                 |`false`|
+| `disable_safe_directory` | The action needs access to the repo it runs in. For that we need to configure git to mark the repo as a safe directory. You can turn this off by setting this flag.        |`false`|
+
 
 ### Examples
 

--- a/action.yml
+++ b/action.yml
@@ -77,7 +77,7 @@ runs:
         # setup-node doesn't allow absolute paths, so we can't
         # just use `github.action_path` to read this out from the `package.json`
         # any changes to the runtime need to be reflected here
-        node-version-file: 18.17.0
+        node-version: 18.17.0
 
     - name: Install Sentry CLI v2
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -51,11 +51,33 @@ inputs:
   disable_telemetry:
     description: 'The action sends telemetry data and crash reports to Sentry. This helps us improve the action. You can turn this off by setting this flag.'
     required: false
+  disable_safe_directory:
+    description: 'The action needs access to the repo it runs in. For that we need to configure git to mark the repo as a safe directory. You can turn this off by setting this flag.'
+    required: false
 
 runs:
   using: 'composite'
   steps:
-    - uses: volta-cli/action@v4
+    - name: Mark GitHub workspace a safe directory in git
+      if: ${{ inputs.disable_safe_directory != 'true' }}
+      shell: bash
+      run: |
+        git config --global --add safe.directory ${{ github.workspace }}
+
+    - name: Get node version
+      shell: bash
+      run: |
+        echo "NODE_VERSION=$(node -v 2>/dev/null || echo '')" >> $GITHUB_ENV
+
+    - name: Setup node
+      # Only install node if there isn't one already
+      if: env.NODE_VERSION == ''
+      uses: actions/setup-node@v4
+      with:
+        # setup-node doesn't allow absolute paths, so we can't
+        # just use `github.action_path` to read this out from the `package.json`
+        # any changes to the runtime need to be reflected here
+        node-version-file: 18.17.0
 
     - name: Install Sentry CLI v2
       shell: bash
@@ -83,9 +105,11 @@ runs:
         INPUT_STRIP_COMMON_PREFIX: ${{ inputs.strip_common_prefix }}
         INPUT_WORKING_DIRECTORY: ${{ inputs.working_directory }}
         INPUT_DISABLE_TELEMETRY: ${{ inputs.disable_telemetry }}
+        INPUT_DISABLE_SAFE_DIRECTORY: ${{ inputs.disable_safe_directory }}
       shell: bash
       run: npm run start
       working-directory: ${{ github.action_path }}
+
 branding:
   icon: 'triangle'
   color: 'purple'


### PR DESCRIPTION
The action now first checks if node is already installed and if so skips `action/setup-node`, otherwise we ensure node (and thus npm) are installed before running the action.

Additionally, it also marks the `GITHUB_WORKSPACE` as a safe directory for git so the runner can correctly cd into the repo root for automatic release name determination and commit blaming.

Closes: #249