### PR TITLE
fix: Mark `GITHUB_WORKSPACE` a safe git directory

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,6 +61,24 @@ jobs:
         with:
           ignore_missing: true
 
+  runs-on-container:
+    runs-on: ubuntu-latest
+    container:
+      image: node:18.17
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create a staging release
+        uses: ./
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_LOG_LEVEL: debug
+        with:
+          ignore_missing: true
+
   mock-release:
     strategy:
       matrix:

--- a/action.yml
+++ b/action.yml
@@ -62,7 +62,7 @@ runs:
       if: ${{ inputs.disable_safe_directory != 'true' }}
       shell: bash
       run: |
-        git config --global --add safe.directory ${{ github.workspace }}
+        git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
     - name: Get node version
       shell: bash


### PR DESCRIPTION
We previously marked `${{ github.workspace }}` as a safe git directory and used `GITHUB_WORKSPACE` in the action's JS to cd into the repo path. This works well on normal jobs, but for jobs that use containers `${{ github.workspace }}` and `GITHUB_WORKSPACE` differ from each other.

As a general rule of thumb for the future:

Use `${{ github.workspace }}` on steps but `$GITHUB_WORKSPACE` on `run` instructutions.

Closes: #249 