### PR TITLE
fix(ci): Set git identity in prior step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,13 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set git user to getsentry-bot
+        if: github.ref == 'refs/heads/master'
+        run: |
+          echo "GIT_COMMITTER_NAME=getsentry-bot" >> $GITHUB_ENV;
+          echo "GIT_AUTHOR_NAME=getsentry-bot" >> $GITHUB_ENV;
+          echo "EMAIL=bot@sentry.io" >> $GITHUB_ENV;
+
       - name: Evaluate docker tag
         run: |
           if [[ "${{ github.ref }}" == "refs/heads/master" ]]; then
@@ -46,10 +53,6 @@ jobs:
             yarn set-docker-tag master
 
             if ! git diff --quiet action.yml; then
-              echo "GIT_COMMITTER_NAME=getsentry-bot" >> $GITHUB_ENV;
-              echo "GIT_AUTHOR_NAME=getsentry-bot" >> $GITHUB_ENV;
-              echo "EMAIL=bot@sentry.io" >> $GITHUB_ENV;
-
               git add action.yml
               SKIP=lint,format,set-docker-tag-from-branch git commit -m "chore: Set docker tag for master [skip-ci]"
               git push

--- a/action.yml
+++ b/action.yml
@@ -84,7 +84,7 @@ runs:
         INPUT_WORKING_DIRECTORY: ${{ inputs.working_directory }}
         INPUT_DISABLE_TELEMETRY: ${{ inputs.disable_telemetry }}
         INPUT_DISABLE_SAFE_DIRECTORY: ${{ inputs.disable_safe_directory }}
-      uses: docker://ghcr.io/getsentry/action-release-image:ab-hybrid-action
+      uses: docker://ghcr.io/getsentry/action-release-image:ab-set-git-identity
 
     # For actions running on macos or windows runners, we use a composite
     # action approach which allows us to install the arch specific sentry-cli


### PR DESCRIPTION
Previous run failed on master: https://github.com/getsentry/action-release/actions/runs/13563951376/job/37912743930

I think because it sets the user too late. Moved it into its own step.