### PR TITLE
fix(ci): Move updating docker tag into own job to avoid setting it twice per run: when the builder image is built and when the app image is built

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
     permissions:
       contents: write
     outputs:
-      docker_tag: ${{ steps.evaluate_docker_tag.outputs.docker_tag }}
+      docker_tag: ${{ steps.docker_tag.outputs.docker_tag }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -46,15 +46,15 @@ jobs:
           echo "GIT_AUTHOR_NAME=getsentry-bot" >> $GITHUB_ENV;
           echo "EMAIL=bot@sentry.io" >> $GITHUB_ENV;
 
-      - name: Evaluate docker tag
-        id: evaluate_docker_tag
+      - name: Get docker tag
+        id: docker_tag
         run: |
           if [[ "${{ github.ref }}" == "refs/heads/master" ]]; then
-            echo "docker_tag=master" >> "$GITHUB_OUTPUT"
+            echo "docker_tag=master" >> $GITHUB_OUTPUT
             yarn set-docker-tag master
           else
             TAG=$(yq '... | select(has("uses") and .uses | test("docker://ghcr.io/getsentry/action-release-image:.*")) | .uses' action.yml | awk -F':' '{print $3}')
-            echo "docker_tag=$TAG" >> "$GITHUB_OUTPUT"
+            echo "docker_tag=$TAG" >> $GITHUB_OUTPUT
 
             if [[ "${{ github.event_name }}" == "pull_request" ]]; then
               if [[ "$TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,13 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
+      - name: Get auth token
+        id: token
+        uses: actions/create-github-app-token@5d869da34e18e7287c1daad50e0b8ea0f506ce69 # v1.11.0
+        with:
+          app_id: ${{ vars.SENTRY_INTERNAL_APP_ID }}
+          private_key: ${{ secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY }}
+
       - name: Set git user to getsentry-bot
         if: github.ref == 'refs/heads/master'
         run: |
@@ -45,12 +52,6 @@ jobs:
           if [[ "${{ github.ref }}" == "refs/heads/master" ]]; then
             echo "docker_tag=master" >> "$GITHUB_OUTPUT"
             yarn set-docker-tag master
-
-            if ! git diff --quiet action.yml; then
-              git add action.yml
-              SKIP=lint,format,set-docker-tag-from-branch git commit -m "chore: Set docker tag for master [skip-ci]"
-              git push
-            fi
           else
             TAG=$(yq '... | select(has("uses") and .uses | test("docker://ghcr.io/getsentry/action-release-image:.*")) | .uses' action.yml | awk -F':' '{print $3}')
             echo "docker_tag=$TAG" >> "$GITHUB_OUTPUT"
@@ -63,6 +64,13 @@ jobs:
               fi
             fi
           fi
+
+      - name: Commit changes
+        uses: getsentry/action-github-commit@v2.0.0
+        if: github.ref == 'refs/heads/master'
+        with:
+          github-token: ${{ steps.token.outputs.token }}
+          message: "chore: Set docker tag for master [skip-ci]"
 
   docker-build:
     name: Build & publish Docker images

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,20 +32,6 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      - name: Get auth token
-        id: token
-        uses: actions/create-github-app-token@5d869da34e18e7287c1daad50e0b8ea0f506ce69 # v1.11.0
-        with:
-          app_id: ${{ vars.SENTRY_INTERNAL_APP_ID }}
-          private_key: ${{ secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY }}
-
-      - name: Set git user to getsentry-bot
-        if: github.ref == 'refs/heads/master'
-        run: |
-          echo "GIT_COMMITTER_NAME=getsentry-bot" >> $GITHUB_ENV;
-          echo "GIT_AUTHOR_NAME=getsentry-bot" >> $GITHUB_ENV;
-          echo "EMAIL=bot@sentry.io" >> $GITHUB_ENV;
-
       - name: Get docker tag
         id: docker_tag
         run: |
@@ -64,6 +50,13 @@ jobs:
               fi
             fi
           fi
+
+      - name: Get auth token
+        id: token
+        uses: actions/create-github-app-token@5d869da34e18e7287c1daad50e0b8ea0f506ce69 # v1.11.0
+        with:
+          app_id: ${{ vars.SENTRY_INTERNAL_APP_ID }}
+          private_key: ${{ secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY }}
 
       - name: Commit changes
         uses: getsentry/action-github-commit@v2.0.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,11 +21,54 @@ env:
   SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
 
 jobs:
-  docker-build:
-    name: Build & publish Docker images
+  prepare-docker:
+    name: Prepare docker tag
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      docker_tag: ${{ steps.evaluate_docker_tag.outputs.docker_tag }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Set git user to getsentry-bot
+        if: github.ref == 'refs/heads/master'
+        run: |
+          echo "GIT_COMMITTER_NAME=getsentry-bot" >> $GITHUB_ENV;
+          echo "GIT_AUTHOR_NAME=getsentry-bot" >> $GITHUB_ENV;
+          echo "EMAIL=bot@sentry.io" >> $GITHUB_ENV;
+
+      - name: Evaluate docker tag
+        id: evaluate_docker_tag
+        run: |
+          if [[ "${{ github.ref }}" == "refs/heads/master" ]]; then
+            echo "docker_tag=master" >> "$GITHUB_OUTPUT"
+            yarn set-docker-tag master
+
+            if ! git diff --quiet action.yml; then
+              git add action.yml
+              SKIP=lint,format,set-docker-tag-from-branch git commit -m "chore: Set docker tag for master [skip-ci]"
+              git push
+            fi
+          else
+            TAG=$(yq '... | select(has("uses") and .uses | test("docker://ghcr.io/getsentry/action-release-image:.*")) | .uses' action.yml | awk -F':' '{print $3}')
+            echo "docker_tag=$TAG" >> "$GITHUB_OUTPUT"
+
+            if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+              if [[ "$TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                echo "Error: docker_tag $TAG matching format MAJOR.MINOR.PATCH is not allowed inside pull requests."
+                echo "Please rename the docker tag in action.yml and try again."
+                exit 1
+              fi
+            fi
+          fi
+
+  docker-build:
+    name: Build & publish Docker images
+    needs: prepare-docker
+    runs-on: ubuntu-latest
+    permissions:
       packages: write
     strategy:
       matrix:
@@ -39,39 +82,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - name: Set git user to getsentry-bot
-        if: github.ref == 'refs/heads/master'
-        run: |
-          echo "GIT_COMMITTER_NAME=getsentry-bot" >> $GITHUB_ENV;
-          echo "GIT_AUTHOR_NAME=getsentry-bot" >> $GITHUB_ENV;
-          echo "EMAIL=bot@sentry.io" >> $GITHUB_ENV;
-
-      - name: Evaluate docker tag
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_SENTRY_BOT_PAT }}
-        run: |
-          if [[ "${{ github.ref }}" == "refs/heads/master" ]]; then
-            echo "DOCKER_TAG=master" >> $GITHUB_ENV
-            yarn set-docker-tag master
-
-            if ! git diff --quiet action.yml; then
-              git add action.yml
-              SKIP=lint,format,set-docker-tag-from-branch git commit -m "chore: Set docker tag for master [skip-ci]"
-              git push
-            fi
-          else
-            TAG=$(yq '... | select(has("uses") and .uses | test("docker://ghcr.io/getsentry/action-release-image:.*")) | .uses' action.yml | awk -F':' '{print $3}')
-            echo "DOCKER_TAG=$TAG" >> $GITHUB_ENV
-
-            if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-              if [[ "$TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-                echo "Error: DOCKER_TAG $TAG matching format MAJOR.MINOR.PATCH is not allowed inside pull requests."
-                echo "Please rename the docker tag in action.yml and try again."
-                exit 1
-              fi
-            fi
-          fi
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -98,7 +108,7 @@ jobs:
         with:
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ghcr.io/${{ github.repository_owner }}/${{ matrix.target.image }}:${{ env.DOCKER_TAG }}
+          tags: ghcr.io/${{ github.repository_owner }}/${{ matrix.target.image }}:${{ needs.prepare-docker.outputs.docker_tag }}
           cache-from: ghcr.io/${{ github.repository_owner }}/${{ matrix.target.image }}:master
           target: ${{ matrix.target.name }}
           build-args: BUILDKIT_INLINE_CACHE=1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,6 +54,7 @@ jobs:
       - name: Get auth token
         id: token
         uses: actions/create-github-app-token@5d869da34e18e7287c1daad50e0b8ea0f506ce69 # v1.11.0
+        if: github.ref == 'refs/heads/master'
         with:
           app_id: ${{ vars.SENTRY_INTERNAL_APP_ID }}
           private_key: ${{ secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY }}

--- a/action.yml
+++ b/action.yml
@@ -84,7 +84,7 @@ runs:
         INPUT_WORKING_DIRECTORY: ${{ inputs.working_directory }}
         INPUT_DISABLE_TELEMETRY: ${{ inputs.disable_telemetry }}
         INPUT_DISABLE_SAFE_DIRECTORY: ${{ inputs.disable_safe_directory }}
-      uses: docker://ghcr.io/getsentry/action-release-image:master
+      uses: docker://ghcr.io/getsentry/action-release-image:ab-set-docker-tag-once
 
     # For actions running on macos or windows runners, we use a composite
     # action approach which allows us to install the arch specific sentry-cli


### PR DESCRIPTION
Previously, when the CI triggers for master, the action changes the docker tag back from whatever was committed in a branch to `master` and commits and pushes this change back to the master branch.

However, because the job is run ist run twice, once for the builder docker image and once for the app docker image, that step was executed twice, trying to commit and push twice.

We only want to do this once, so I extracted this up into its own job that the building job depends on.