### PR TITLE
fix(ci): Use correct label to skip ci on master runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
         if: github.ref == 'refs/heads/master'
         with:
           github-token: ${{ steps.token.outputs.token }}
-          message: "chore: Set docker tag for master [skip-ci]"
+          message: "chore: Set docker tag for master [skip ci]"
 
   docker-build:
     name: Build & publish Docker images

--- a/action.yml
+++ b/action.yml
@@ -84,7 +84,7 @@ runs:
         INPUT_WORKING_DIRECTORY: ${{ inputs.working_directory }}
         INPUT_DISABLE_TELEMETRY: ${{ inputs.disable_telemetry }}
         INPUT_DISABLE_SAFE_DIRECTORY: ${{ inputs.disable_safe_directory }}
-      uses: docker://ghcr.io/getsentry/action-release-image:master
+      uses: docker://ghcr.io/getsentry/action-release-image:ab-skip-ci
 
     # For actions running on macos or windows runners, we use a composite
     # action approach which allows us to install the arch specific sentry-cli


### PR DESCRIPTION
Noticed CI still runs when the action switches back the docker tag to master. According to https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/skipping-workflow-runs the label should be `[skip ci]` not `[skip-ci]`.