### PR TITLE
feat(sourcemaps)!: Enable injecting debug ids by default

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,9 @@ repos:
     rev: v5.0.0
     hooks:
       - id: trailing-whitespace
+        exclude: '^dist/.*'
       - id: end-of-file-fixer
+        exclude: '^dist/.*'
       - id: check-yaml
   - repo: local
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 3.0.0
+
+Version `3.0.0` contains breaking changes:
+
+- feat(sourcemaps)!: Enable injecting debug ids by default (#272) by @andreiborza
+
+The action now automatically injects Debug IDs into your JavaScript source files and source maps to ensure your stacktraces can be
+properly un-minified.
+
+This is a **breaking change as it modifies your source files**. You can disable this behavior by setting `inject: false`:
+
+```yaml
+- uses: getsentry/action-release@v3
+  with:
+    environment: 'production'
+    sourcemaps: './dist'
+    inject: false
+```
+
+Read more about [Artifact Bundles and Debug IDs here](https://docs.sentry.io/platforms/javascript/sourcemaps/troubleshooting_js/artifact-bundles/).
+
 ## 1.11.0
 
 - feat: Use hybrid docker/composite action approach (#265) by @andreiborza

--- a/README.md
+++ b/README.md
@@ -23,6 +23,15 @@ Additionally, releases are used for applying [source maps](https://docs.sentry.i
 
 ## What's new
 
+Version `3.0.0` contains breaking changes:
+
+- feat(sourcemaps)!: Enable injecting debug ids by default (#272) by @andreiborza
+
+The action now automatically injects Debug IDs into your JavaScript source files and source maps to ensure your stacktraces can be
+properly un-minified.
+
+This is a **breaking change as it modifies your source files**. You can disable this behavior by setting `inject: false`.
+
 Please refer to the [release page](https://github.com/getsentry/action-release/releases) for the latest release notes.
 
 ## Prerequisites
@@ -42,7 +51,7 @@ Adding the following to your workflow will create a new Sentry release and tell 
     fetch-depth: 0
 
 - name: Create Sentry release
-  uses: getsentry/action-release@v1
+  uses: getsentry/action-release@v3
   env:
     SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
     SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
@@ -68,8 +77,8 @@ Adding the following to your workflow will create a new Sentry release and tell 
 | name                     | description                                                                                                                                                                |default|
 |--------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---|
 | `environment`            | Set the environment for this release. E.g. "production" or "staging". Omit to skip adding deploy to release.                                                               |-|
-| `inject`                 | Injects Debug IDs into source files and sourcemaps. We **strongly recommend enabling** this to ensure proper un-minifaction of your stacktraces.                           |`false`|
 | `sourcemaps`             | Space-separated list of paths to JavaScript sourcemaps. Omit to skip uploading sourcemaps.                                                                                 |-|
+| `inject`                 | Injects Debug IDs into source files and source maps to ensure proper un-minifcation of your stacktraces. Does nothing if `sourcemaps` was not set.                         |`true`|
 | `finalize`               | When false, omit marking the release as finalized and released.                                                                                                            |`true`|
 | `ignore_missing`         | When the flag is set and the previous release commit was not found in the repository, will create a release with the default commits count instead of failing the command. |`false`|
 | `ignore_empty`           | When the flag is set, command will not fail and just exit silently if no new commits for a given release have been found.                                                  |`false`|
@@ -88,20 +97,19 @@ Adding the following to your workflow will create a new Sentry release and tell 
 
 ### Examples
 
-- Create a new Sentry release for the `production` environment, inject Debug IDs into JavaScript source files and sourcemaps and upload them from the `./dist` directory.
+- Create a new Sentry release for the `production` environment, inject Debug IDs into JavaScript source files and source maps and upload them from the `./dist` directory.
 
     ```yaml
-    - uses: getsentry/action-release@v1
+    - uses: getsentry/action-release@v3
       with:
         environment: 'production'
-        inject: true
         sourcemaps: './dist'
     ```
 
 - Create a new Sentry release for the `production` environment of your project at version `v1.0.1`.
 
     ```yaml
-    - uses: getsentry/action-release@v1
+    - uses: getsentry/action-release@v3
       with:
         environment: 'production'
         version: 'v1.0.1'
@@ -110,7 +118,7 @@ Adding the following to your workflow will create a new Sentry release and tell 
 - Create a new Sentry release for [Self-Hosted Sentry](https://develop.sentry.dev/self-hosted/)
 
     ```yaml
-    - uses: getsentry/action-release@v1
+    - uses: getsentry/action-release@v3
       env:
         SENTRY_URL: https://sentry.example.com/
     ```
@@ -177,7 +185,7 @@ Otherwise it could fail at the `propose-version` step with the message:
       with:
         fetch-depth: 0
 
-    - uses: getsentry/action-release@v1
+    - uses: getsentry/action-release@v3
       with:
         environment: 'production'
         version: 'v1.0.1'

--- a/action.yml
+++ b/action.yml
@@ -6,11 +6,12 @@ inputs:
   environment:
     description: 'Set the environment for this release. E.g. "production" or "staging". Omit to skip adding deploy to release.'
     required: false
-  inject:
-    description: 'Injects Debug IDs into source files and sourcemaps. We strongly recommend enabling this to ensure proper un-minifaction of your stacktraces.'
-    required: false
   sourcemaps:
-    description: 'Space-separated list of paths to JavaScript sourcemaps. Omit to skip uploading sourcemaps.'
+    description: 'Space-separated list of paths to JavaScript source maps. Omit to skip uploading sourcemaps.'
+    required: false
+  inject:
+    description: 'Injects Debug IDs into source files and source maps to ensure proper un-minifcation of your stacktraces. Does nothing if `sourcemaps` was not set.'
+    default: true
     required: false
   dist:
     description: 'Unique identifier for the distribution, used to further segment your release. Usually your build number.'
@@ -20,9 +21,11 @@ inputs:
     default: true
   ignore_missing:
     description: 'When the flag is set and the previous release commit was not found in the repository, will create a release with the default commits count instead of failing the command.'
+    default: false
     required: false
   ignore_empty:
     description: 'When the flag is set, command will not fail and just exit silently if no new commits for a given release have been found.'
+    default: false
     required: false
   started_at:
     description: 'Unix timestamp of the release start date. Omit for current time.'
@@ -44,15 +47,18 @@ inputs:
     required: false
   strip_common_prefix:
     description: 'Will remove a common prefix from uploaded filenames. Useful for removing a path that is build-machine-specific.'
+    default: false
     required: false
   working_directory:
     description: 'Directory to collect sentry release information from. Useful when collecting information from a non-standard checkout directory.'
     required: false
   disable_telemetry:
     description: 'The action sends telemetry data and crash reports to Sentry. This helps us improve the action. You can turn this off by setting this flag.'
+    default: false
     required: false
   disable_safe_directory:
     description: 'The action needs access to the repo it runs in. For that we need to configure git to mark the repo as a safe directory. You can turn this off by setting this flag.'
+    default: false
     required: false
 
 runs:
@@ -84,7 +90,7 @@ runs:
         INPUT_WORKING_DIRECTORY: ${{ inputs.working_directory }}
         INPUT_DISABLE_TELEMETRY: ${{ inputs.disable_telemetry }}
         INPUT_DISABLE_SAFE_DIRECTORY: ${{ inputs.disable_safe_directory }}
-      uses: docker://ghcr.io/getsentry/action-release-image:master
+      uses: docker://ghcr.io/getsentry/action-release-image:ab-inject-by-default
 
     # For actions running on macos or windows runners, we use a composite
     # action approach which allows us to install the arch specific sentry-cli

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,7 +22,7 @@ withTelemetry(
       options.checkEnvironmentVariables();
 
       const environment = options.getEnvironment();
-      const inject = options.getBooleanOption('inject', false);
+      const inject = options.getBooleanOption('inject', true);
       const sourcemaps = options.getSourcemaps();
       const dist = options.getDist();
       const shouldFinalize = options.getBooleanOption('finalize', true);


### PR DESCRIPTION
This PR will flip the default value of `inject` from `false` to `true` to inject Debug IDs by default when users specify `sourcemaps`.

This is a breaking change and requires a new major.

Closes: #221 