### PR TITLE
feat: Add `release` and `release_prefix` in favor of `version` and `version_prefix` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 3.1.0
+
+- feat: Add `release` and `release_prefix` in favor of `version` and `version_prefix`
+
+Input parameter `version` has been deprecated and will be removed in a future version in favor of a newly introduced `release` parameter.
+
+Input parameter `version_prefix` has been deprecated and will be removed in a future version in favor of a newly introduced `release_prefix` parameter.
+
 ## 3.0.0
 
 Version `3.0.0` contains breaking changes:

--- a/README.md
+++ b/README.md
@@ -23,14 +23,7 @@ Additionally, releases are used for applying [source maps](https://docs.sentry.i
 
 ## What's new
 
-Version `3.0.0` contains breaking changes:
-
-- feat(sourcemaps)!: Enable injecting debug ids by default (#272) by @andreiborza
-
-The action now automatically injects Debug IDs into your JavaScript source files and source maps to ensure your stacktraces can be
-properly un-minified.
-
-This is a **breaking change as it modifies your source files**. You can disable this behavior by setting `inject: false`.
+Version 3 is out with improved support for source maps. We highly recommend upgrading to `getsentry/action-release@v3`.
 
 Please refer to the [release page](https://github.com/getsentry/action-release/releases) for the latest release notes.
 
@@ -74,25 +67,27 @@ Adding the following to your workflow will create a new Sentry release and tell 
 
 #### Parameters
 
-| name                     | description                                                                                                                                                                |default|
-|--------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---|
-| `environment`            | Set the environment for this release. E.g. "production" or "staging". Omit to skip adding deploy to release.                                                               |-|
-| `sourcemaps`             | Space-separated list of paths to JavaScript sourcemaps. Omit to skip uploading sourcemaps.                                                                                 |-|
-| `inject`                 | Injects Debug IDs into source files and source maps to ensure proper un-minifcation of your stacktraces. Does nothing if `sourcemaps` was not set.                         |`true`|
-| `finalize`               | When false, omit marking the release as finalized and released.                                                                                                            |`true`|
-| `ignore_missing`         | When the flag is set and the previous release commit was not found in the repository, will create a release with the default commits count instead of failing the command. |`false`|
-| `ignore_empty`           | When the flag is set, command will not fail and just exit silently if no new commits for a given release have been found.                                                  |`false`|
-| `dist`                   | Unique identifier for the distribution, used to further segment your release. Usually your build number.                                                                   |-|
-| `started_at`             | Unix timestamp of the release start date. Omit for current time.                                                                                                           |-|
-| `version`                | Identifier that uniquely identifies the releases. _Note: the `refs/tags/` prefix is automatically stripped when `version` is `github.ref`._                                |<code>${{&nbsp;github.sha&nbsp;}}</code>|
-| `version_prefix`         | Value prepended to auto-generated version. For example "v".                                                                                                                |-|
-| `set_commits`            | Specify whether to set commits for the release. Either "auto" or "skip".                                                                                                   |"auto"|
-| `projects`               | Space-separated list of paths of projects. When omitted, falls back to the environment variable `SENTRY_PROJECT` to determine the project.                                 |-|
-| `url_prefix`             | Adds a prefix to source map urls after stripping them.                                                                                                                     |-|
-| `strip_common_prefix`    | Will remove a common prefix from uploaded filenames. Useful for removing a path that is build-machine-specific.                                                            |`false`|
-| `working_directory`      | Directory to collect sentry release information from. Useful when collecting information from a non-standard checkout directory.                                           |-|
-| `disable_telemetry`      | The action sends telemetry data and crash reports to Sentry. This helps us improve the action. You can turn this off by setting this flag.                                 |`false`|
-| `disable_safe_directory` | The action needs access to the repo it runs in. For that we need to configure git to mark the repo as a safe directory. You can turn this off by setting this flag.        |`false`|
+| name                      | description                                                                                                                                                                                                                 |default|
+|---------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---|
+| `environment`             | Set the environment for this release. E.g. "production" or "staging". Omit to skip adding deploy to release.                                                                                                                |-|
+| `sourcemaps`              | Space-separated list of paths to JavaScript sourcemaps. Omit to skip uploading sourcemaps.                                                                                                                                  |-|
+| `inject`                  | Injects Debug IDs into source files and source maps to ensure proper un-minifcation of your stacktraces. Does nothing if `sourcemaps` was not set.                                                                          |`true`|
+| `finalize`                | When false, omit marking the release as finalized and released.                                                                                                                                                             |`true`|
+| `ignore_missing`          | When the flag is set and the previous release commit was not found in the repository, will create a release with the default commits count instead of failing the command.                                                  |`false`|
+| `ignore_empty`            | When the flag is set, command will not fail and just exit silently if no new commits for a given release have been found.                                                                                                   |`false`|
+| `dist`                    | Unique identifier for the distribution, used to further segment your release. Usually your build number.                                                                                                                    |-|
+| `started_at`              | Unix timestamp of the release start date. Omit for current time.                                                                                                                                                            |-|
+| `release`                 | Identifier that uniquely identifies the releases. Should match the `release` property in your Sentry SDK init call if one was set._Note: the `refs/tags/` prefix is automatically stripped when `version` is `github.ref`._ |<code>${{&nbsp;github.sha&nbsp;}}</code>|
+| `version`                 | Deprecated: Use `release` instead.                                                                                                                                                                                          |<code>${{&nbsp;github.sha&nbsp;}}</code>|
+| `release_prefix`          | Value prepended to auto-generated version. For example "v".                                                                                                                                                                 |-|
+| `version_prefix`          | Deprecated: Use `release_prefix` instead.                                                                                                                                                                                 |-|
+| `set_commits`             | Specify whether to set commits for the release. Either "auto" or "skip".                                                                                                                                                    |"auto"|
+| `projects`                | Space-separated list of paths of projects. When omitted, falls back to the environment variable `SENTRY_PROJECT` to determine the project.                                                                                  |-|
+| `url_prefix`              | Adds a prefix to source map urls after stripping them.                                                                                                                                                                      |-|
+| `strip_common_prefix`     | Will remove a common prefix from uploaded filenames. Useful for removing a path that is build-machine-specific.                                                                                                             |`false`|
+| `working_directory`       | Directory to collect sentry release information from. Useful when collecting information from a non-standard checkout directory.                                                                                            |-|
+| `disable_telemetry`       | The action sends telemetry data and crash reports to Sentry. This helps us improve the action. You can turn this off by setting this flag.                                                                                  |`false`|
+| `disable_safe_directory`  | The action needs access to the repo it runs in. For that we need to configure git to mark the repo as a safe directory. You can turn this off by setting this flag.                                                         |`false`|
 
 
 ### Examples
@@ -112,7 +107,7 @@ Adding the following to your workflow will create a new Sentry release and tell 
     - uses: getsentry/action-release@v3
       with:
         environment: 'production'
-        version: 'v1.0.1'
+        release: 'v1.0.1'
     ```
 
 - Create a new Sentry release for [Self-Hosted Sentry](https://develop.sentry.dev/self-hosted/)
@@ -150,8 +145,8 @@ Suggestions and issues can be posted on the repository's
     Syntax error: end of file unexpected (expecting ")")
     ```
 
-- When adding the action, make sure to first checkout your repo with `actions/checkout@v3`.
-Otherwise it could fail at the `propose-version` step with the message:
+- When adding the action, make sure to first check out your repo with `actions/checkout@v4`.
+Otherwise, it could fail at the `propose-version` step with the message:
 
     ```text
     error: Could not automatically determine release name
@@ -188,5 +183,5 @@ Otherwise it could fail at the `propose-version` step with the message:
     - uses: getsentry/action-release@v3
       with:
         environment: 'production'
-        version: 'v1.0.1'
+        release: 'v1.0.1'
     ```

--- a/action.yml
+++ b/action.yml
@@ -4,60 +4,116 @@ author: 'Sentry'
 
 inputs:
   environment:
-    description: 'Set the environment for this release. E.g. "production" or "staging". Omit to skip adding deploy to release.'
+    description: |-
+      Set the environment for this release. E.g. "production" or "staging".
+      Omit to skip adding deploy to release.
     required: false
   sourcemaps:
-    description: 'Space-separated list of paths to JavaScript source maps. Omit to skip uploading sourcemaps.'
+    description: |-
+      Space-separated list of paths to JavaScript source maps.
+      Omit to skip uploading sourcemaps.
     required: false
   inject:
-    description: 'Injects Debug IDs into source files and source maps to ensure proper un-minifcation of your stacktraces. Does nothing if `sourcemaps` was not set.'
+    description: |-
+      Injects Debug IDs into source files and source maps to ensure proper
+      un-minifcation of your stacktraces.
+      Does nothing if "sourcemaps" was not set.
     default: true
     required: false
   dist:
-    description: 'Unique identifier for the distribution, used to further segment your release. Usually your build number.'
+    description: |-
+      Unique identifier for the distribution, used to further segment your
+      release.
+      Usually your build number.
     required: false
   finalize:
-    description: 'When false, omit marking the release as finalized and released.'
+    description: |-
+      When false, omit marking the release as finalized and released.
     default: true
   ignore_missing:
-    description: 'When the flag is set and the previous release commit was not found in the repository, will create a release with the default commits count instead of failing the command.'
+    description: |-
+      When the flag is set and the previous release commit was not found in
+      the repository, will create a release with the default commits count
+      instead of failing the command.
     default: false
     required: false
   ignore_empty:
-    description: 'When the flag is set, command will not fail and just exit silently if no new commits for a given release have been found.'
+    description: |-
+      When the flag is set, command will not fail and just exit silently if no
+      new commits for a given release have been found.
     default: false
     required: false
   started_at:
-    description: 'Unix timestamp of the release start date. Omit for current time.'
+    description: |-
+      Unix timestamp of the release start date. Omit for current time.
     required: false
   version:
-    description: 'Identifier that uniquely identifies the releases. Omit to auto-generate one.'
+    description: |-
+      Identifier that uniquely identifies the release.
+      Should match the "release" property in your Sentry SDK init call if one
+      was set.
+      Omit to auto-generate one.
+    deprecationMessage: |-
+      Deprecated: Use "release" instead.
+    required: false
+  release:
+    description: |-
+      Identifier that uniquely identifies the release.
+      Should match the "release" property in your Sentry SDK init call if one
+      was set.
+      Omit to auto-generate one.
     required: false
   version_prefix:
-    description: 'Value prepended to auto-generated version.'
+    description: |-
+      Value prepended to auto-generated version.
+    deprecationMessage: |-
+      Deprecated: Use "release_prefix" instead.
+    required: false
+  release_prefix:
+    description: |-
+      Value prepended to auto-generated release version.
     required: false
   set_commits:
-    description: 'Specify whether to set commits for the release. Either "auto" or "skip".'
+    description: |-
+      Specify whether to set commits for the release.
+      One of: "auto", "skip"
     required: false
   projects:
-    description: 'Space-separated list of projects. Defaults to the env variable "SENTRY_PROJECT" if not provided.'
+    description: |-
+      Space-separated list of projects.
+      Defaults to the env variable "SENTRY_PROJECT" if not provided.
     required: false
   url_prefix:
-    description: 'Adds a prefix to source map urls after stripping them.'
+    description: |-
+      Adds a prefix to source map urls after stripping them.
     required: false
   strip_common_prefix:
-    description: 'Will remove a common prefix from uploaded filenames. Useful for removing a path that is build-machine-specific.'
+    description: |-
+      Will remove a common prefix from uploaded filenames. Useful for removing
+      a path that is build-machine-specific.
+      Note: Will not remove common prefixes across two or more directories
+      provided to "sourcemap". E.g. Setting
+      "sourcemap": "./dist/js ./dist/asset/js" will strip "./dist" for the first
+      directory and "./dist/assets/js" for the
     default: false
     required: false
   working_directory:
-    description: 'Directory to collect sentry release information from. Useful when collecting information from a non-standard checkout directory.'
+    description: |-
+      Directory to collect sentry release information from.
+      Useful when collecting information from a non-standard checkout directory.
     required: false
   disable_telemetry:
-    description: 'The action sends telemetry data and crash reports to Sentry. This helps us improve the action. You can turn this off by setting this flag.'
+    description: |-
+      The action sends telemetry data and crash reports to Sentry. This helps
+      us improve the action.
+      You can turn this off by setting this flag.
     default: false
     required: false
   disable_safe_directory:
-    description: 'The action needs access to the repo it runs in. For that we need to configure git to mark the repo as a safe directory. You can turn this off by setting this flag.'
+    description: |-
+      The action needs access to the repo it runs in. For that we need to
+      configure git to mark the repo directory a safe directory.
+      You can turn this off by setting this flag.
     default: false
     required: false
 
@@ -82,7 +138,9 @@ runs:
         INPUT_IGNORE_EMPTY: ${{ inputs.ignore_empty }}
         INPUT_STARTED_AT: ${{ inputs.started_at }}
         INPUT_VERSION: ${{ inputs.version }}
+        INPUT_RELEASE: ${{ inputs.release }}
         INPUT_VERSION_PREFIX: ${{ inputs.version_prefix }}
+        INPUT_RELEASE_PREFIX: ${{ inputs.release_prefix }}
         INPUT_SET_COMMITS: ${{ inputs.set_commits }}
         INPUT_PROJECTS: ${{ inputs.projects }}
         INPUT_URL_PREFIX: ${{ inputs.url_prefix }}
@@ -90,7 +148,7 @@ runs:
         INPUT_WORKING_DIRECTORY: ${{ inputs.working_directory }}
         INPUT_DISABLE_TELEMETRY: ${{ inputs.disable_telemetry }}
         INPUT_DISABLE_SAFE_DIRECTORY: ${{ inputs.disable_safe_directory }}
-      uses: docker://ghcr.io/getsentry/action-release-image:master
+      uses: docker://ghcr.io/getsentry/action-release-image:ab-deprecate-version
 
     # For actions running on macos or windows runners, we use a composite
     # action approach which allows us to install the arch specific sentry-cli
@@ -132,7 +190,9 @@ runs:
         INPUT_IGNORE_EMPTY: ${{ inputs.ignore_empty }}
         INPUT_STARTED_AT: ${{ inputs.started_at }}
         INPUT_VERSION: ${{ inputs.version }}
+        INPUT_RELEASE: ${{ inputs.release }}
         INPUT_VERSION_PREFIX: ${{ inputs.version_prefix }}
+        INPUT_RELEASE_PREFIX: ${{ inputs.release_prefix }}
         INPUT_SET_COMMITS: ${{ inputs.set_commits }}
         INPUT_PROJECTS: ${{ inputs.projects }}
         INPUT_URL_PREFIX: ${{ inputs.url_prefix }}

--- a/src/options.ts
+++ b/src/options.ts
@@ -7,23 +7,31 @@ import {getCLI} from './cli';
  * @throws
  * @returns Promise<string>
  */
-export const getVersion = async (): Promise<string> => {
+export const getRelease = async (): Promise<string> => {
+  // TODO(v4): Remove `version` and `version_prefix`, they were deprecated in v3
+  const releaseOption: string = core.getInput('release');
   const versionOption: string = core.getInput('version');
+  const releasePrefixOption: string = core.getInput('release_prefix');
   const versionPrefixOption: string = core.getInput('version_prefix');
-  let version = '';
-  if (versionOption) {
-    // If the users passes in `${{github.ref}}, then it will have an unwanted prefix.
-    version = versionOption.replace(/^(refs\/tags\/)/, '');
+
+  let release = '';
+  if (releaseOption || versionOption) {
+    // Prefer `release` over the deprecated `version`
+    release = releaseOption ? releaseOption : versionOption;
+    // If users pass `${{ github.ref }}, strip the unwanted `refs/tags` prefix
+    release = release.replace(/^(refs\/tags\/)/, '');
   } else {
-    core.debug('Version not provided, proposing one...');
-    version = await getCLI().proposeVersion();
+    core.debug('Release version not provided, proposing one...');
+    release = await getCLI().proposeVersion();
   }
 
-  if (versionPrefixOption) {
-    version = `${versionPrefixOption}${version}`;
+  if (releasePrefixOption) {
+    release = `${releasePrefixOption}${release}`;
+  } else if (versionPrefixOption) {
+    release = `${versionPrefixOption}${release}`;
   }
 
-  return version;
+  return release;
 };
 
 /**


### PR DESCRIPTION
`version` (and `version_prefix`) have been confusing to users. In our SDKs, we use the parameter `release`.

This PR adds `release*` versions of both parameters and deprecates the old ones to be removed in a future version.

Closes: https://github.com/getsentry/action-release/issues/40