### PR TITLE
fix: Only pass `urlPrefix` to sentry-cli if it's not empty 

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,11 +1,11 @@
 {
-  "printWidth": 80,
+  "printWidth": 120,
   "tabWidth": 2,
   "useTabs": false,
   "semi": true,
   "singleQuote": true,
   "trailingComma": "es5",
-  "bracketSpacing": false,
+  "bracketSpacing": true,
   "arrowParens": "avoid",
   "overrides": [
     {

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -1,4 +1,4 @@
-import {execSync} from 'child_process';
+import { execSync } from 'child_process';
 import * as path from 'path';
 import * as process from 'process';
 import {
@@ -29,9 +29,7 @@ describe('options', () => {
 
     test('should throw an error when option type is not a boolean', () => {
       process.env['INPUT_FINALIZE'] = 'error';
-      expect(() => getBooleanOption(option, defaultValue)).toThrow(
-        errorMessage
-      );
+      expect(() => getBooleanOption(option, defaultValue)).toThrow(errorMessage);
     });
 
     test('should return defaultValue if option is omitted', () => {
@@ -84,8 +82,7 @@ describe('options', () => {
   });
 
   describe('getStartedAt', () => {
-    const errorMessage =
-      'started_at not in valid format. Unix timestamp or ISO 8601 date expected';
+    const errorMessage = 'started_at not in valid format. Unix timestamp or ISO 8601 date expected';
     afterEach(() => {
       delete process.env['INPUT_STARTED_AT'];
     });
@@ -121,10 +118,10 @@ describe('options', () => {
   });
 
   describe.each([
-    {release: 'INPUT_RELEASE', prefix: 'INPUT_RELEASE_PREFIX'},
-    {release: 'INPUT_VERSION', prefix: 'INPUT_VERSION_PREFIX'},
-    {release: 'INPUT_RELEASE', prefix: 'INPUT_VERSION_PREFIX'},
-    {release: 'INPUT_VERSION', prefix: 'INPUT_RELEASE_PREFIX'},
+    { release: 'INPUT_RELEASE', prefix: 'INPUT_RELEASE_PREFIX' },
+    { release: 'INPUT_VERSION', prefix: 'INPUT_VERSION_PREFIX' },
+    { release: 'INPUT_RELEASE', prefix: 'INPUT_VERSION_PREFIX' },
+    { release: 'INPUT_VERSION', prefix: 'INPUT_RELEASE_PREFIX' },
   ])(`getRelease`, params => {
     const MOCK_VERSION = 'releases propose-version';
 
@@ -250,9 +247,7 @@ describe('options', () => {
     it('gets the working directory url and prefixes it with the `GITHUB_WORKSPACE`', () => {
       process.env['GITHUB_WORKSPACE'] = '/repo/root';
       process.env['INPUT_WORKING_DIRECTORY'] = '/some/working/directory';
-      expect(getWorkingDirectory()).toEqual(
-        '/repo/root/some/working/directory'
-      );
+      expect(getWorkingDirectory()).toEqual('/repo/root/some/working/directory');
     });
 
     it('should default to `GITHUB_WORKSPACE` even if no direcotry is passed', () => {
@@ -264,19 +259,16 @@ describe('options', () => {
 
 // shows how the runner will run a javascript action with env / stdout protocol
 test('test runs', () => {
-  const output = execSync(
-    `node ${path.join(__dirname, '..', 'dist', 'index.js')}`,
-    {
-      env: {
-        ...process.env,
-        INPUT_ENVIRONMENT: 'production',
-        MOCK: 'true',
-        SENTRY_AUTH_TOKEN: 'test_token',
-        SENTRY_ORG: 'test_org',
-        SENTRY_PROJECT: 'test_project',
-      },
-    }
-  );
+  const output = execSync(`node ${path.join(__dirname, '..', 'dist', 'index.js')}`, {
+    env: {
+      ...process.env,
+      INPUT_ENVIRONMENT: 'production',
+      MOCK: 'true',
+      SENTRY_AUTH_TOKEN: 'test_token',
+      SENTRY_ORG: 'test_org',
+      SENTRY_PROJECT: 'test_project',
+    },
+  });
 
   console.log(output.toString());
 });

--- a/action.yml
+++ b/action.yml
@@ -148,7 +148,7 @@ runs:
         INPUT_WORKING_DIRECTORY: ${{ inputs.working_directory }}
         INPUT_DISABLE_TELEMETRY: ${{ inputs.disable_telemetry }}
         INPUT_DISABLE_SAFE_DIRECTORY: ${{ inputs.disable_safe_directory }}
-      uses: docker://ghcr.io/getsentry/action-release-image:3.1.0
+      uses: docker://ghcr.io/getsentry/action-release-image:ab-avoid-sending-empty-urlPrefix
 
     # For actions running on macos or windows runners, we use a composite
     # action approach which allows us to install the arch specific sentry-cli

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,7 @@
-import {getTraceData} from '@sentry/node';
-import SentryCli, {SentryCliReleases} from '@sentry/cli';
+import { getTraceData } from '@sentry/node';
+import SentryCli, { SentryCliReleases } from '@sentry/cli';
 // @ts-ignore
-import {version} from '../package.json';
+import { version } from '../package.json';
 
 /**
  * CLI Singleton

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,10 +1,10 @@
 import * as Sentry from '@sentry/node';
 import * as core from '@actions/core';
-import {SentryCliUploadSourceMapsOptions} from '@sentry/cli';
-import {getCLI} from './cli';
+import { SentryCliUploadSourceMapsOptions } from '@sentry/cli';
+import { getCLI } from './cli';
 import * as options from './options';
 import * as process from 'process';
-import {isTelemetryEnabled, traceStep, withTelemetry} from './telemetry';
+import { isTelemetryEnabled, traceStep, withTelemetry } from './telemetry';
 
 withTelemetry(
   {
@@ -33,10 +33,7 @@ withTelemetry(
       const setCommitsOption = options.getSetCommitsOption();
       const projects = options.getProjects();
       const urlPrefix = options.getUrlPrefixOption();
-      const stripCommonPrefix = options.getBooleanOption(
-        'strip_common_prefix',
-        false
-      );
+      const stripCommonPrefix = options.getBooleanOption('strip_common_prefix', false);
       const release = await options.getRelease();
 
       if (projects.length === 1) {
@@ -46,7 +43,7 @@ withTelemetry(
       }
 
       core.debug(`Release version is ${release}`);
-      await getCLI().new(release, {projects});
+      await getCLI().new(release, { projects });
 
       Sentry.setTag('set-commits', setCommitsOption);
 
@@ -69,10 +66,7 @@ withTelemetry(
           await traceStep('inject-debug-ids', async () => {
             core.debug(`Injecting Debug IDs`);
             // Unfortunately, @sentry/cli does not yet have an alias for inject
-            await getCLI().execute(
-              ['sourcemaps', 'inject', ...sourcemaps],
-              true
-            );
+            await getCLI().execute(['sourcemaps', 'inject', ...sourcemaps], true);
           });
         }
 
@@ -96,7 +90,7 @@ withTelemetry(
               getCLI().uploadSourceMaps(release, {
                 ...sourceMapsOptions,
                 projects: [project],
-              } as SentryCliUploadSourceMapsOptions & {projects: string[]})
+              } as SentryCliUploadSourceMapsOptions & { projects: string[] })
             )
           );
 
@@ -109,7 +103,7 @@ withTelemetry(
           core.debug(`Adding deploy to release`);
           await getCLI().newDeploy(release, {
             env: environment,
-            ...(deployStartedAtOption && {started: deployStartedAtOption}),
+            ...(deployStartedAtOption && { started: deployStartedAtOption }),
           });
         });
       }

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,6 +1,6 @@
 import * as core from '@actions/core';
 import path from 'path';
-import {getCLI} from './cli';
+import { getCLI } from './cli';
 
 /**
  * Get the release version string from parameter or propose one.
@@ -69,9 +69,7 @@ export const getStartedAt = (): number | null => {
   }
 
   if (!outputTimestamp || outputTimestamp < 0) {
-    throw new Error(
-      'started_at not in valid format. Unix timestamp or ISO 8601 date expected'
-    );
+    throw new Error('started_at not in valid format. Unix timestamp or ISO 8601 date expected');
   }
 
   return outputTimestamp;
@@ -109,10 +107,7 @@ export const getDist = (): string | undefined => {
  * @param defaultValue boolean
  * @returns boolean
  */
-export const getBooleanOption = (
-  input: string,
-  defaultValue: boolean
-): boolean => {
+export const getBooleanOption = (input: string, defaultValue: boolean): boolean => {
   const option = core.getInput(input);
   if (!option) {
     return defaultValue;
@@ -156,11 +151,7 @@ export const getSetCommitsOption = (): 'auto' | 'skip' => {
 export const checkEnvironmentVariables = (): void => {
   if (process.env['MOCK']) {
     // Set environment variables for mock runs if they aren't already
-    for (const variable of [
-      'SENTRY_AUTH_TOKEN',
-      'SENTRY_ORG',
-      'SENTRY_PROJECT',
-    ]) {
+    for (const variable of ['SENTRY_AUTH_TOKEN', 'SENTRY_ORG', 'SENTRY_PROJECT']) {
       if (!(variable in process.env)) {
         process.env[variable] = variable;
       }
@@ -168,14 +159,10 @@ export const checkEnvironmentVariables = (): void => {
   }
 
   if (!process.env['SENTRY_ORG']) {
-    throw Error(
-      'Environment variable SENTRY_ORG is missing an organization slug'
-    );
+    throw Error('Environment variable SENTRY_ORG is missing an organization slug');
   }
   if (!process.env['SENTRY_AUTH_TOKEN']) {
-    throw Error(
-      'Environment variable SENTRY_AUTH_TOKEN is missing an auth token'
-    );
+    throw Error('Environment variable SENTRY_AUTH_TOKEN is missing an auth token');
   }
 };
 
@@ -205,8 +192,5 @@ export const getWorkingDirectory = (): string => {
   // The action runs inside `github.action_path` and as such
   // doesn't automatically have access to the user's git
   // We prefix all paths with `GITHUB_WORKSPACE` which is at the top of the repo.
-  return path.join(
-    process.env.GITHUB_WORKSPACE || '',
-    core.getInput('working_directory')
-  );
+  return path.join(process.env.GITHUB_WORKSPACE || '', core.getInput('working_directory'));
 };

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -8,10 +8,7 @@ const SENTRY_SAAS_HOSTNAME = 'sentry.io';
  * Initializes Sentry and wraps the given callback
  * in a span.
  */
-export async function withTelemetry<F>(
-  options: {enabled: boolean},
-  callback: () => F | Promise<F>
-): Promise<F> {
+export async function withTelemetry<F>(options: { enabled: boolean }, callback: () => F | Promise<F>): Promise<F> {
   Sentry.initWithoutDefaultIntegrations({
     dsn: 'https://2172f0c14072ba401de59317df8ded93@o1.ingest.us.sentry.io/4508608809533441',
     enabled: options.enabled,
@@ -27,7 +24,7 @@ export async function withTelemetry<F>(
 
   const org = process.env['SENTRY_ORG'];
 
-  Sentry.setUser({id: org});
+  Sentry.setUser({ id: org });
   Sentry.setTag('organization', org);
   Sentry.setTag('node', process.version);
   Sentry.setTag('platform', process.platform);
@@ -68,7 +65,7 @@ export function updateProgress(step: string): void {
  */
 export function traceStep<T>(step: string, callback: () => T): T {
   updateProgress(step);
-  return Sentry.startSpan({name: step, op: 'action.step'}, () => callback());
+  return Sentry.startSpan({ name: step, op: 'action.step' }, () => callback());
 }
 
 /**
@@ -87,9 +84,7 @@ export async function safeFlush(): Promise<void> {
  * Check whether the user is self-hosting Sentry.
  */
 export function isSelfHosted(): boolean {
-  const url = new URL(
-    process.env['SENTRY_URL'] || `https://${SENTRY_SAAS_HOSTNAME}`
-  );
+  const url = new URL(process.env['SENTRY_URL'] || `https://${SENTRY_SAAS_HOSTNAME}`);
 
   return url.hostname !== SENTRY_SAAS_HOSTNAME;
 }
@@ -98,7 +93,5 @@ export function isSelfHosted(): boolean {
  * Determine if telemetry should be enabled.
  */
 export function isTelemetryEnabled(): boolean {
-  return (
-    !ciOptions.getBooleanOption('disable_telemetry', false) && !isSelfHosted()
-  );
+  return !ciOptions.getBooleanOption('disable_telemetry', false) && !isSelfHosted();
 }


### PR DESCRIPTION
Please see 511c3f336b17a1b394c793d5919d16ba64886ecd for the relevant changes.
<hr/>
I also reworked how projects are passed to the CLI. Previously the CLI was invoked once per project, but I saw that sentry-cli does actually support passing multiple projects so I reworked that.

Here's a screenshot from the report email showing the two projects I specified in a private repo.

![Screenshot 2025-03-19 at 16 55 49@2x](https://github.com/user-attachments/assets/05523c03-9dd2-49b5-ba38-3abf967cd819)
<hr/>
Closes: #137 