### PR TITLE
fix: Preserve existing Node version on macOS and Windows runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
         if: github.ref == 'refs/heads/master'
         with:
           github-token: ${{ steps.token.outputs.token }}
-          message: "chore: Set docker tag for master [skip ci]"
+          message: 'chore: Set docker tag for master [skip ci]'
 
   docker-build:
     name: Build & publish Docker images
@@ -222,3 +222,48 @@ jobs:
         with:
           environment: production
           working_directory: ./test
+
+  test-node-version-preserved:
+    needs: docker-build
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        node-version: ['20.x', '22.x']
+    runs-on: ${{ matrix.os }}
+    name: Test Node version preserved on ${{ matrix.os }} with Node ${{ matrix.node-version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Print Node Version (Before)
+        id: node_before
+        shell: bash
+        run: |
+          VERSION=$(node --version)
+          echo "Node version before: $VERSION"
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Mock creating a Sentry release
+        uses: ./
+        env:
+          MOCK: true
+        with:
+          environment: production
+
+      - name: Print Node Version (After)
+        shell: bash
+        run: |
+          VERSION_AFTER=$(node --version)
+          echo "Node version after: $VERSION_AFTER"
+          echo "Expected: ${{ steps.node_before.outputs.VERSION }}"
+          if [ "$VERSION_AFTER" != "${{ steps.node_before.outputs.VERSION }}" ]; then
+            echo "ERROR: Node version changed from ${{ steps.node_before.outputs.VERSION }} to $VERSION_AFTER"
+            exit 1
+          fi
+          echo "SUCCESS: Node version preserved"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.1.2
+
+- fix: Preserve existing Node version on macOS and Windows runners (#280) by @andreiborza
+
 ## 3.1.1
 
 - fix: Only pass `urlPrefix` to sentry-cli if it's not empty (#275) by @andreiborza

--- a/action.yml
+++ b/action.yml
@@ -148,7 +148,7 @@ runs:
         INPUT_WORKING_DIRECTORY: ${{ inputs.working_directory }}
         INPUT_DISABLE_TELEMETRY: ${{ inputs.disable_telemetry }}
         INPUT_DISABLE_SAFE_DIRECTORY: ${{ inputs.disable_safe_directory }}
-      uses: docker://ghcr.io/getsentry/action-release-image:master
+      uses: docker://ghcr.io/getsentry/action-release-image:ab-restore-node-version
 
     # For actions running on macos or windows runners, we use a composite
     # action approach which allows us to install the arch specific sentry-cli
@@ -159,6 +159,16 @@ runs:
       shell: bash
       run: |
         git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+    # Save the current Node version before changing it
+    - name: Save current Node version
+      if: runner.os == 'macOS' || runner.os == 'Windows'
+      id: node_version
+      shell: bash
+      run: |
+        if command -v node &> /dev/null; then
+          echo "NODE_VERSION=$(node --version | sed 's/v//')" >> $GITHUB_OUTPUT
+        fi
 
     - name: Setup node
       if: runner.os == 'macOS' || runner.os == 'Windows'
@@ -203,6 +213,13 @@ runs:
       shell: bash
       run: npm run start
       working-directory: ${{ github.action_path }}
+
+    # Restore the original Node version
+    - name: Restore original Node version
+      if: (runner.os == 'macOS' || runner.os == 'Windows') && steps.node_version.outputs.NODE_VERSION != ''
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ steps.node_version.outputs.NODE_VERSION }}
 
 branding:
   icon: 'triangle'


### PR DESCRIPTION
The action now saves and restores the original Node version when running on macOS and Windows runners, preventing it from permanently changing the Node version for subsequent workflow steps. This ensures the action doesn't interfere with other steps that may require a specific Node version.

Fixes: #279