### PR TITLE
chore: Update release runner to `ubuntu-latest`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: "Action: Prepare Release"
+name: 'Action: Prepare Release'
 
 on:
   workflow_dispatch:
@@ -18,7 +18,7 @@ jobs:
   release:
     name: Release a new version
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Get auth token

--- a/action.yml
+++ b/action.yml
@@ -148,7 +148,7 @@ runs:
         INPUT_WORKING_DIRECTORY: ${{ inputs.working_directory }}
         INPUT_DISABLE_TELEMETRY: ${{ inputs.disable_telemetry }}
         INPUT_DISABLE_SAFE_DIRECTORY: ${{ inputs.disable_safe_directory }}
-      uses: docker://ghcr.io/getsentry/action-release-image:master
+      uses: docker://ghcr.io/getsentry/action-release-image:ab-update-release-runners
 
     # For actions running on macos or windows runners, we use a composite
     # action approach which allows us to install the arch specific sentry-cli


### PR DESCRIPTION
Can't release because `ubuntu-20.04` has been [removed in April](https://github.com/actions/runner-images/issues/11101).