### PR TITLE
chore: Bump to Node 24 LTS and setup-node v6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -236,7 +236,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node-version: ['20.x', '22.x']
+        node-version: ['20.x', '22.x', '24.x']
     runs-on: ${{ matrix.os }}
     name: Test Node version preserved on ${{ matrix.os }} with Node ${{ matrix.node-version }}
     permissions:

--- a/action.yml
+++ b/action.yml
@@ -167,7 +167,7 @@ runs:
         INPUT_WORKING_DIRECTORY: ${{ inputs.working_directory }}
         INPUT_DISABLE_TELEMETRY: ${{ inputs.disable_telemetry }}
         INPUT_DISABLE_SAFE_DIRECTORY: ${{ inputs.disable_safe_directory }}
-      uses: docker://ghcr.io/getsentry/action-release-image:master
+      uses: docker://ghcr.io/getsentry/action-release-image:ab-bump-node
 
     # For actions running on macos or windows runners, we use a composite
     # action approach which allows us to install the arch specific sentry-cli
@@ -191,12 +191,13 @@ runs:
 
     - name: Setup node
       if: runner.os == 'macOS' || runner.os == 'Windows'
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
       with:
         # setup-node doesn't allow absolute paths, so we can't
         # just use `github.action_path` to read this out from the `package.json`
         # any changes to the runtime need to be reflected here
-        node-version: 20.19.2
+        node-version: 24.14.1
+        package-manager-cache: false
 
     - name: Install Sentry CLI v2
       if: runner.os == 'macOS' || runner.os == 'Windows'
@@ -239,9 +240,10 @@ runs:
     # Restore the original Node version
     - name: Restore original Node version
       if: (runner.os == 'macOS' || runner.os == 'Windows') && steps.node_version.outputs.NODE_VERSION != ''
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
       with:
         node-version: ${{ steps.node_version.outputs.NODE_VERSION }}
+        package-manager-cache: false
 
 branding:
   icon: 'triangle'

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@types/jest": "^29.5.6",
-    "@types/node": "^20.8.9",
+    "@types/node": "^24.0.0",
     "@typescript-eslint/parser": "^6.9.0",
     "@vercel/ncc": "^0.38.1",
     "eslint": "^8.52.0",
@@ -47,7 +47,7 @@
     "typescript": "^5.2.2"
   },
   "volta": {
-    "node": "20.19.2",
+    "node": "24.14.1",
     "yarn": "1.22.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1229,12 +1229,19 @@
   dependencies:
     "@types/node" "*"
 
-"@types/node@*", "@types/node@^20.8.9":
+"@types/node@*":
   version "20.8.9"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.8.9.tgz#646390b4fab269abce59c308fc286dcd818a2b08"
   integrity sha512-UzykFsT3FhHb1h7yD4CA4YhBHq545JC0YnEz41xkipN88eKQtL6rSgocL5tbAP6Ola9Izm/Aw4Ora8He4x0BHg==
   dependencies:
     undici-types "~5.26.4"
+
+"@types/node@^24.0.0":
+  version "24.12.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-24.12.0.tgz#6222e028210e5322e4f4f6767f8d88e5ea3b33d2"
+  integrity sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==
+  dependencies:
+    undici-types "~7.16.0"
 
 "@types/pg-pool@2.0.6":
   version "2.0.6"
@@ -4554,6 +4561,11 @@ undici-types@~5.26.4:
   version "5.26.5"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
   integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
+
+undici-types@~7.16.0:
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.16.0.tgz#ffccdff36aea4884cbfce9a750a0580224f58a46"
+  integrity sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==
 
 undici@^5.28.5:
   version "5.29.0"


### PR DESCRIPTION
- Bump Node.js runtime from 20.19.2 to 24.14.1
- Bump `actions/setup-node` from v4.4.0 to v6.3.0
- Bump `@types/node` from ^20 to ^24
- Update Volta config to Node 24.14.1
- Add Node 24.x to CI test matrix

> [!IMPORTANT]
> `actions/setup-node@v6` runs on the `node24` Actions runtime, which
> requires **runner version v2.327.1 or later**. 
> Self-hosted runners on macOS or Windows using an older runner version 
> will need to upgrade. Linux runners are unaffected. 
>
> GitHub-hosted runners are already compatible.

Closes: #312