### PR TITLE
feat(sentry-cli): Upgrade to 2.58.6

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -167,7 +167,7 @@ runs:
         INPUT_WORKING_DIRECTORY: ${{ inputs.working_directory }}
         INPUT_DISABLE_TELEMETRY: ${{ inputs.disable_telemetry }}
         INPUT_DISABLE_SAFE_DIRECTORY: ${{ inputs.disable_safe_directory }}
-      uses: docker://ghcr.io/getsentry/action-release-image:3.6.1
+      uses: docker://ghcr.io/getsentry/action-release-image:szokeasaurusrex-bump-sentry-cli-to-safe-version
 
     # For actions running on macos or windows runners, we use a composite
     # action approach which allows us to install the arch specific sentry-cli

--- a/action.yml
+++ b/action.yml
@@ -202,7 +202,7 @@ runs:
     - name: Install Sentry CLI v2
       if: runner.os == 'macOS' || runner.os == 'Windows'
       shell: bash
-      run: npm install --no-package-lock @sentry/cli@^2.4
+      run: npm install --no-package-lock @sentry/cli@^2.58.6
       working-directory: ${{ github.action_path }}
 
     - name: Run Release Action


### PR DESCRIPTION
Upgrade sentry-cli to [2.58.6](https://github.com/getsentry/sentry-cli/releases/tag/2.58.6), which includes security fixes.