### PR TITLE
ci: limit GITHUB_TOKEN permissions for lint and check-dist

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,6 +117,8 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/.github/workflows/verify-dist.yml
+++ b/.github/workflows/verify-dist.yml
@@ -20,6 +20,8 @@ jobs:
     name: Verify dist/index.js file
 
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/action.yml
+++ b/action.yml
@@ -167,7 +167,7 @@ runs:
         INPUT_WORKING_DIRECTORY: ${{ inputs.working_directory }}
         INPUT_DISABLE_TELEMETRY: ${{ inputs.disable_telemetry }}
         INPUT_DISABLE_SAFE_DIRECTORY: ${{ inputs.disable_safe_directory }}
-      uses: docker://ghcr.io/getsentry/action-release-image:ab-bump-sentry-node-v10
+      uses: docker://ghcr.io/getsentry/action-release-image:ab-add-workflow-permissions
 
     # For actions running on macos or windows runners, we use a composite
     # action approach which allows us to install the arch specific sentry-cli


### PR DESCRIPTION
## What

Adds `permissions: contents: read` to the `lint` job in `build.yml` and the `check-dist` job in `verify-dist.yml`. Both only check out the repo and run local commands.

## Why

Closes the two open CodeQL alerts for `actions/missing-workflow-permissions`. These were the last two jobs without an explicit permissions block.